### PR TITLE
Added hierarchical folder support for scratchpads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,13 @@ src/
 │   │       ├── BookmarkFolderTreeItem.ts
 │   │       └── BookmarkDragAndDropController.ts
 │   └── scratchpads/
-│       ├── Models.ts             # ScratchFile, ScratchpadData interfaces
-│       ├── ScratchpadAiTools.ts  # GitHub Copilot language model tools (scratchpad list/read/create/rename/delete)
+│       ├── Models.ts             # ScratchFile, ScratchpadFolder, ScratchpadData interfaces
+│       ├── ScratchpadAiTools.ts  # GitHub Copilot language model tools (9 tools)
 │       ├── ScratchpadService.ts
+│       ├── ScratchpadValidator.ts # Input validation (file/folder name, count limits)
 │       ├── ScratchpadCommands.ts
 │       ├── ScratchpadsProvider.ts
+│       ├── ScratchpadFolderTreeItem.ts  # Tree item for folder nodes
 │       ├── index.ts
 │       └── views/
 │           ├── ScratchpadItem.ts
@@ -95,7 +97,7 @@ Each feature (`todos`, `bookmarks`, `scratchpads`) follows the same layered stru
 ### GitHub Copilot Tools
 - Tools are contributed via `package.json` → `contributes.languageModelTools` and registered with `vscode.lm.registerTool(...)`.
 - Bookmark tools (8): `codebench_get_bookmarks`, `codebench_add_bookmark`, `codebench_move_bookmark_to_folder`, `codebench_rename_bookmark`, `codebench_set_bookmark_color`, `codebench_remove_bookmark`, `codebench_create_bookmark_folder`, `codebench_remove_bookmark_folder`.
-- Scratchpad tools (5): `codebench_get_scratchpads`, `codebench_get_scratchpad_content`, `codebench_create_scratchpad`, `codebench_rename_scratchpad`, `codebench_delete_scratchpad`.
+- Scratchpad tools (9): `codebench_get_scratchpads`, `codebench_get_scratchpad_content`, `codebench_create_scratchpad`, `codebench_update_scratchpad_content`, `codebench_rename_scratchpad`, `codebench_delete_scratchpad`, `codebench_create_scratchpad_folder`, `codebench_move_scratchpad_to_folder`, `codebench_delete_scratchpad_folder`.
 - Tool outputs are JSON text payloads wrapped in `LanguageModelToolResult`.
 
 ## Build & Development Commands
@@ -145,6 +147,7 @@ Tests require a VS Code instance (Extension Host). On headless CI, `xvfb-run` is
 ## Business Rules & Limits
 - Todos: max 100 total items, max 2 levels of nesting (parent → child → grandchild), text 1–75 chars
 - Bookmarks: max 200 items, folder depth up to 3 levels, bookmark text 1–75 chars, folder name 1–75 chars
+- Scratchpads: max 200 files, folder depth up to 5 levels, file text 1–75 chars, folder name 1–75 chars
 - Bookmark colors: `default` (blue), `red`, `green`, `yellow`, `purple`
 - All commands are prefixed with `vs-codebench.`
 

--- a/package.json
+++ b/package.json
@@ -192,6 +192,30 @@
         "command": "vs-codebench.clearAllScratchpads",
         "title": "Scratchpads: Clear All",
         "category": "CodeBench"
+      },
+      {
+        "command": "vs-codebench.addScratchpadFolder",
+        "title": "Add Scratchpad Folder",
+        "icon": "$(new-folder)",
+        "category": "CodeBench"
+      },
+      {
+        "command": "vs-codebench.addRootScratchpadFolder",
+        "title": "New Scratchpad Folder",
+        "icon": "$(new-folder)",
+        "category": "CodeBench"
+      },
+      {
+        "command": "vs-codebench.editScratchpadFolder",
+        "title": "Edit Scratchpad Folder",
+        "icon": "$(edit)",
+        "category": "CodeBench"
+      },
+      {
+        "command": "vs-codebench.deleteScratchpadFolder",
+        "title": "Delete Scratchpad Folder",
+        "icon": "$(trash)",
+        "category": "CodeBench"
       }
     ],
     "languageModelTools": [
@@ -401,6 +425,10 @@
             "nameContains": {
               "type": "string",
               "description": "Optional case-insensitive substring for scratchpad name filtering."
+            },
+            "folderId": {
+              "type": "string",
+              "description": "Optional folder ID to filter scratchpads by parent folder."
             }
           },
           "additionalProperties": false
@@ -446,6 +474,33 @@
             "content": {
               "type": "string",
               "description": "Optional initial file content."
+            },
+            "parentFolderId": {
+              "type": "string",
+              "description": "Optional folder ID to create the scratchpad inside."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "codebench_update_scratchpad_content",
+        "displayName": "Update Scratchpad Content",
+        "userDescription": "Update the content of an existing scratchpad.",
+        "modelDescription": "Update the full file content for an existing VS CodeBench scratchpad by scratchpadId. Use this to overwrite the entire content of a scratchpad.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "codebench-update-scratchpad-content",
+        "inputSchema": {
+          "type": "object",
+          "required": ["scratchpadId", "content"],
+          "properties": {
+            "scratchpadId": {
+              "type": "string",
+              "description": "ID of scratchpad to update."
+            },
+            "content": {
+              "type": "string",
+              "description": "New content to write to the scratchpad file."
             }
           },
           "additionalProperties": false
@@ -488,6 +543,71 @@
             "scratchpadId": {
               "type": "string",
               "description": "ID of scratchpad to delete."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "codebench_create_scratchpad_folder",
+        "displayName": "Create Scratchpad Folder",
+        "userDescription": "Create a scratchpad folder in VS CodeBench.",
+        "modelDescription": "Create a scratchpad folder at root or under a parent folder. Folder depth limit is 5.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "codebench-create-scratchpad-folder",
+        "inputSchema": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Folder name (1-75 characters)."
+            },
+            "parentFolderId": {
+              "type": "string",
+              "description": "Optional parent folder ID."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "codebench_move_scratchpad_to_folder",
+        "displayName": "Move Scratchpad To Folder",
+        "userDescription": "Move an existing scratchpad into a scratchpad folder.",
+        "modelDescription": "Place an existing VS CodeBench scratchpad into a specific folder. Use get_scratchpads first to resolve scratchpadId and folderId.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "codebench-move-scratchpad-folder",
+        "inputSchema": {
+          "type": "object",
+          "required": ["scratchpadId", "folderId"],
+          "properties": {
+            "scratchpadId": {
+              "type": "string",
+              "description": "Existing scratchpad ID to move into a folder."
+            },
+            "folderId": {
+              "type": "string",
+              "description": "Target scratchpad folder ID."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "codebench_delete_scratchpad_folder",
+        "displayName": "Delete Scratchpad Folder",
+        "userDescription": "Delete a scratchpad folder and its contents.",
+        "modelDescription": "Delete a scratchpad folder by folderId. Recursively removes all nested subfolders and moves contained scratchpads to root.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "codebench-delete-scratchpad-folder",
+        "inputSchema": {
+          "type": "object",
+          "required": ["folderId"],
+          "properties": {
+            "folderId": {
+              "type": "string",
+              "description": "ID of folder to delete."
             }
           },
           "additionalProperties": false
@@ -574,6 +694,11 @@
           "command": "vs-codebench.createScratchpad",
           "when": "view == scratchpadsView",
           "group": "navigation"
+        },
+        {
+          "command": "vs-codebench.addRootScratchpadFolder",
+          "when": "view == scratchpadsView",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [
@@ -641,6 +766,21 @@
           "command": "vs-codebench.deleteScratchFile",
           "when": "view == scratchpadsView && viewItem == scratchpadItem",
           "group": "inline@2"
+        },
+        {
+          "command": "vs-codebench.addScratchpadFolder",
+          "when": "view == scratchpadsView && viewItem == scratchpadFolder",
+          "group": "inline@0"
+        },
+        {
+          "command": "vs-codebench.editScratchpadFolder",
+          "when": "view == scratchpadsView && (viewItem == scratchpadFolder || viewItem == scratchpadFolderMaxDepth)",
+          "group": "inline@1"
+        },
+        {
+          "command": "vs-codebench.deleteScratchpadFolder",
+          "when": "view == scratchpadsView && (viewItem == scratchpadFolder || viewItem == scratchpadFolderMaxDepth)",
+          "group": "inline@3"
         }
       ],
       "editor/context": [

--- a/src/features/scratchpads/Models.ts
+++ b/src/features/scratchpads/Models.ts
@@ -6,11 +6,23 @@ export interface ScratchFile {
     createdAt: number;
     lastModified: number;
     order?: number;
+    parentId?: string;  // ID of parent folder
+}
+
+export interface ScratchpadFolder {
+    id: string;
+    name: string;
+    parentId?: string;  // ID of parent folder (for subfolders)
+    createdAt: number;
+    updatedAt: number;
+    order: number;
+    isExpanded?: boolean;
 }
 
 export interface ScratchpadData {
     version: number;
     files: ScratchFile[];
+    folders?: ScratchpadFolder[];
 }
 
-export const CURRENT_SCRATCHPAD_VERSION = 1;
+export const CURRENT_SCRATCHPAD_VERSION = 2;

--- a/src/features/scratchpads/ScratchpadAiTools.ts
+++ b/src/features/scratchpads/ScratchpadAiTools.ts
@@ -4,6 +4,7 @@ import { ScratchpadsProvider } from './ScratchpadsProvider';
 interface GetScratchpadsInput {
   language?: string;
   nameContains?: string;
+  folderId?: string;
 }
 
 interface GetScratchpadContentInput {
@@ -14,6 +15,7 @@ interface CreateScratchpadInput {
   name?: string;
   language?: string;
   content?: string;
+  parentFolderId?: string;
 }
 
 interface RenameScratchpadInput {
@@ -21,8 +23,27 @@ interface RenameScratchpadInput {
   newName: string;
 }
 
+interface UpdateScratchpadContentInput {
+  scratchpadId: string;
+  content: string;
+}
+
 interface DeleteScratchpadInput {
   scratchpadId: string;
+}
+
+interface CreateScratchpadFolderInput {
+  name: string;
+  parentFolderId?: string;
+}
+
+interface MoveScratchpadToFolderInput {
+  scratchpadId: string;
+  folderId: string;
+}
+
+interface DeleteScratchpadFolderInput {
+  folderId: string;
 }
 
 function resultFromObject(payload: unknown): vscode.LanguageModelToolResult {
@@ -38,6 +59,7 @@ function toScratchpadMetadata(scratchpad: {
   createdAt: number;
   lastModified: number;
   order?: number;
+  parentId?: string;
 }) {
   return {
     id: scratchpad.id,
@@ -45,7 +67,26 @@ function toScratchpadMetadata(scratchpad: {
     language: scratchpad.language,
     createdAt: scratchpad.createdAt,
     lastModified: scratchpad.lastModified,
-    order: scratchpad.order
+    order: scratchpad.order,
+    parentId: scratchpad.parentId
+  };
+}
+
+function toFolderMetadata(folder: {
+  id: string;
+  name: string;
+  parentId?: string;
+  createdAt: number;
+  updatedAt: number;
+  order: number;
+}) {
+  return {
+    id: folder.id,
+    name: folder.name,
+    parentId: folder.parentId,
+    createdAt: folder.createdAt,
+    updatedAt: folder.updatedAt,
+    order: folder.order
   };
 }
 
@@ -58,6 +99,13 @@ class GetScratchpadsTool implements vscode.LanguageModelTool<GetScratchpadsInput
     const input = options.input ?? {};
     let scratchpads = this.scratchpadsProvider.getAllScratchpads();
 
+    if (input.folderId !== undefined) {
+      scratchpads = scratchpads.filter(file => file.parentId === input.folderId);
+    } else {
+      // Default: show root-level only (backwards compatible)
+      scratchpads = scratchpads.filter(file => !file.parentId);
+    }
+
     if (input.language) {
       const language = input.language.toLowerCase();
       scratchpads = scratchpads.filter(file => (file.language ?? '').toLowerCase() === language);
@@ -68,9 +116,12 @@ class GetScratchpadsTool implements vscode.LanguageModelTool<GetScratchpadsInput
       scratchpads = scratchpads.filter(file => file.name.toLowerCase().includes(nameContains));
     }
 
+    const folders = this.scratchpadsProvider.scratchpadService.getFolders();
+
     return resultFromObject({
       count: scratchpads.length,
-      scratchpads: scratchpads.map(toScratchpadMetadata)
+      scratchpads: scratchpads.map(toScratchpadMetadata),
+      folders: folders.map(toFolderMetadata)
     });
   }
 }
@@ -114,6 +165,31 @@ class CreateScratchpadTool implements vscode.LanguageModelTool<CreateScratchpadI
   }
 }
 
+class UpdateScratchpadContentTool implements vscode.LanguageModelTool<UpdateScratchpadContentInput> {
+  constructor(private scratchpadsProvider: ScratchpadsProvider) {}
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<UpdateScratchpadContentInput>
+  ): Promise<vscode.LanguageModelToolResult> {
+    const input = options.input;
+    const scratchpad = this.scratchpadsProvider.getScratchpadById(input.scratchpadId);
+    if (!scratchpad) {
+      throw new Error('Scratchpad not found. Provide a valid scratchpadId.');
+    }
+
+    await this.scratchpadsProvider.updateScratchpadContentForTools(input.scratchpadId, input.content);
+
+    const content = this.scratchpadsProvider.getScratchpadContentForTools(input.scratchpadId);
+    return resultFromObject({
+      success: true,
+      scratchpad: {
+        ...toScratchpadMetadata(scratchpad),
+        content
+      }
+    });
+  }
+}
+
 class RenameScratchpadTool implements vscode.LanguageModelTool<RenameScratchpadInput> {
   constructor(private scratchpadsProvider: ScratchpadsProvider) {}
 
@@ -147,6 +223,70 @@ class DeleteScratchpadTool implements vscode.LanguageModelTool<DeleteScratchpadI
   }
 }
 
+class CreateScratchpadFolderTool implements vscode.LanguageModelTool<CreateScratchpadFolderInput> {
+  constructor(private scratchpadsProvider: ScratchpadsProvider) {}
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<CreateScratchpadFolderInput>
+  ): Promise<vscode.LanguageModelToolResult> {
+    const input = options.input;
+    const folder = await this.scratchpadsProvider.addFolder(input.name, input.parentFolderId);
+
+    return resultFromObject({
+      success: true,
+      folder: toFolderMetadata(folder)
+    });
+  }
+}
+
+class MoveScratchpadToFolderTool implements vscode.LanguageModelTool<MoveScratchpadToFolderInput> {
+  constructor(private scratchpadsProvider: ScratchpadsProvider) {}
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<MoveScratchpadToFolderInput>
+  ): Promise<vscode.LanguageModelToolResult> {
+    const input = options.input;
+    const scratchpad = this.scratchpadsProvider.scratchpadService.getScratchFile(input.scratchpadId);
+    if (!scratchpad) {
+      throw new Error('Scratchpad not found. Provide a valid scratchpadId.');
+    }
+
+    const folder = this.scratchpadsProvider.scratchpadService.getFolderById(input.folderId);
+    if (!folder) {
+      throw new Error('Folder not found. Provide a valid folderId.');
+    }
+
+    await this.scratchpadsProvider.moveToFolder(input.scratchpadId, input.folderId);
+    const updated = this.scratchpadsProvider.scratchpadService.getScratchFile(input.scratchpadId);
+
+    return resultFromObject({
+      success: true,
+      scratchpad: updated ? toScratchpadMetadata(updated) : undefined
+    });
+  }
+}
+
+class DeleteScratchpadFolderTool implements vscode.LanguageModelTool<DeleteScratchpadFolderInput> {
+  constructor(private scratchpadsProvider: ScratchpadsProvider) {}
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<DeleteScratchpadFolderInput>
+  ): Promise<vscode.LanguageModelToolResult> {
+    const input = options.input;
+    const folder = this.scratchpadsProvider.scratchpadService.getFolderById(input.folderId);
+    if (!folder) {
+      throw new Error('Folder not found. Provide a valid folderId.');
+    }
+
+    await this.scratchpadsProvider.deleteFolder(input.folderId);
+
+    return resultFromObject({
+      success: true,
+      deletedFolderId: input.folderId
+    });
+  }
+}
+
 export function registerScratchpadAiTools(
   context: vscode.ExtensionContext,
   scratchpadsProvider: ScratchpadsProvider
@@ -155,7 +295,11 @@ export function registerScratchpadAiTools(
     vscode.lm.registerTool('codebench_get_scratchpads', new GetScratchpadsTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_get_scratchpad_content', new GetScratchpadContentTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_create_scratchpad', new CreateScratchpadTool(scratchpadsProvider)),
+    vscode.lm.registerTool('codebench_update_scratchpad_content', new UpdateScratchpadContentTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_rename_scratchpad', new RenameScratchpadTool(scratchpadsProvider)),
-    vscode.lm.registerTool('codebench_delete_scratchpad', new DeleteScratchpadTool(scratchpadsProvider))
+    vscode.lm.registerTool('codebench_delete_scratchpad', new DeleteScratchpadTool(scratchpadsProvider)),
+    vscode.lm.registerTool('codebench_create_scratchpad_folder', new CreateScratchpadFolderTool(scratchpadsProvider)),
+    vscode.lm.registerTool('codebench_move_scratchpad_to_folder', new MoveScratchpadToFolderTool(scratchpadsProvider)),
+    vscode.lm.registerTool('codebench_delete_scratchpad_folder', new DeleteScratchpadFolderTool(scratchpadsProvider))
   );
 }

--- a/src/features/scratchpads/ScratchpadCommands.ts
+++ b/src/features/scratchpads/ScratchpadCommands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ScratchpadsProvider } from './ScratchpadsProvider';
+import ScratchpadValidator from './ScratchpadValidator';
 
 export function registerScratchpadCommands(
   context: vscode.ExtensionContext,
@@ -32,6 +33,52 @@ export function registerScratchpadCommands(
 
     vscode.commands.registerCommand('vs-codebench.clearAllScratchpads', async () => {
       await scratchpadsProvider.clearAllScratchpads();
+    }),
+
+    // Folder commands
+    vscode.commands.registerCommand('vs-codebench.addScratchpadFolder', async (item?: any) => {
+      const folderName = await vscode.window.showInputBox({
+        prompt: 'Enter folder name',
+        placeHolder: 'Folder name',
+        validateInput: ScratchpadValidator.validateFolderName
+      });
+
+      if (folderName) {
+        const parentId = item?.id;
+        await scratchpadsProvider.addFolder(folderName, parentId);
+      }
+    }),
+
+    vscode.commands.registerCommand('vs-codebench.addRootScratchpadFolder', async () => {
+      const folderName = await vscode.window.showInputBox({
+        prompt: 'Enter folder name',
+        placeHolder: 'Folder name',
+        validateInput: ScratchpadValidator.validateFolderName
+      });
+
+      if (folderName) {
+        await scratchpadsProvider.addFolder(folderName, undefined);
+      }
+    }),
+
+    vscode.commands.registerCommand('vs-codebench.editScratchpadFolder', async (item: any) => {
+      if (item && item.id) {
+        const folderName = await vscode.window.showInputBox({
+          prompt: 'Edit folder name',
+          value: item.label,
+          validateInput: ScratchpadValidator.validateFolderName
+        });
+
+        if (folderName && folderName !== item.label) {
+          await scratchpadsProvider.editFolder(item.id, folderName);
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand('vs-codebench.deleteScratchpadFolder', async (item: any) => {
+      if (item && item.id) {
+        await scratchpadsProvider.deleteFolder(item.id);
+      }
     })
   );
 }

--- a/src/features/scratchpads/ScratchpadService.ts
+++ b/src/features/scratchpads/ScratchpadService.ts
@@ -2,11 +2,12 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
-import { ScratchFile, ScratchpadData, CURRENT_SCRATCHPAD_VERSION } from './Models';
+import { ScratchFile, ScratchpadFolder, ScratchpadData, CURRENT_SCRATCHPAD_VERSION } from './Models';
 import { NamespacedStorageService, createNamespacedStorage } from '../../common/storage/StorageService';
 
 export class ScratchpadService {
   private scratchFiles: Map<string, ScratchFile> = new Map();
+  private folders: ScratchpadFolder[] = [];
   private storage: NamespacedStorageService;
 
   constructor(private context: vscode.ExtensionContext) {
@@ -36,13 +37,25 @@ export class ScratchpadService {
     try {
       const data = await this.storage.retrieve<ScratchpadData>('metadata', {
         version: CURRENT_SCRATCHPAD_VERSION,
-        files: []
+        files: [],
+        folders: []
       }, { scope: 'auto' });
 
       this.scratchFiles.clear();
-      data.files.forEach(file => {
-        this.scratchFiles.set(file.id, file);
-      });
+      this.folders = [];
+
+      // v1→v2 migration: initialize parentId on existing files
+      if (data.version < 2) {
+        data.files.forEach(file => {
+          const migrated: ScratchFile = { ...file, parentId: undefined };
+          this.scratchFiles.set(file.id, migrated);
+        });
+      } else {
+        data.files.forEach(file => {
+          this.scratchFiles.set(file.id, file);
+        });
+        this.folders = data.folders || [];
+      }
     } catch (error) {
       console.error('Failed to load scratch files:', error);
     }
@@ -52,12 +65,324 @@ export class ScratchpadService {
     try {
       const data: ScratchpadData = {
         version: CURRENT_SCRATCHPAD_VERSION,
-        files: Array.from(this.scratchFiles.values())
+        files: Array.from(this.scratchFiles.values()),
+        folders: this.folders
       };
       await this.storage.store('metadata', data, { scope: 'auto' });
     } catch (error) {
       console.error('Failed to save metadata:', error);
     }
+  }
+
+  // ─── Folder CRUD ─────────────────────────────────────────────────────────────
+
+  getFolders(): ScratchpadFolder[] {
+    return this.folders;
+  }
+
+  getFolderById(id: string): ScratchpadFolder | undefined {
+    return this.folders.find(f => f.id === id);
+  }
+
+  async addFolder(name: string, parentId?: string): Promise<ScratchpadFolder> {
+    const siblings = this.getFolderSiblings(parentId);
+    const orders = siblings.map(s => s.order).filter((o): o is number => o !== undefined);
+    const maxOrder = orders.length > 0 ? Math.max(...orders) : -1;
+
+    const newFolder: ScratchpadFolder = {
+      id: uuidv4(),
+      name: name.trim(),
+      parentId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      order: maxOrder + 1,
+      isExpanded: true
+    };
+
+    this.folders.push(newFolder);
+    await this.saveMetadata();
+    return newFolder;
+  }
+
+  async editFolder(id: string, name: string): Promise<void> {
+    const folder = this.folders.find(f => f.id === id);
+    if (folder) {
+      folder.name = name.trim();
+      folder.updatedAt = Date.now();
+      await this.saveMetadata();
+    }
+  }
+
+  async deleteFolder(id: string): Promise<void> {
+    const folder = this.folders.find(f => f.id === id);
+    if (!folder) {
+      return;
+    }
+
+    const parentId = folder.parentId;
+    this.deleteFolderRecursive(id);
+
+    // Normalize order after deletion
+    const siblings = this.getFolderSiblings(parentId);
+    siblings.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    siblings.forEach((item, index) => { item.order = index; });
+
+    await this.saveMetadata();
+  }
+
+  private deleteFolderRecursive(folderId: string): void {
+    // Move all files in this folder to root (parentId = undefined)
+    this.scratchFiles.forEach(file => {
+      if (file.parentId === folderId) {
+        file.parentId = undefined;
+      }
+    });
+
+    // Recursively delete subfolders
+    const subfolders = this.folders.filter(f => f.parentId === folderId);
+    for (const subfolder of subfolders) {
+      this.deleteFolderRecursive(subfolder.id);
+    }
+
+    // Delete the folder itself
+    this.folders = this.folders.filter(f => f.id !== folderId);
+  }
+
+  async moveToFolder(itemId: string, targetFolderId?: string): Promise<void> {
+    // Moving a scratchpad file
+    const file = this.scratchFiles.get(itemId);
+    if (file) {
+      const sourceParentId = file.parentId;
+
+      const targetSiblings = this.getFolderSiblings(targetFolderId);
+      const targetOrders = targetSiblings.map(s => s.order).filter((o): o is number => o !== undefined);
+      const maxOrder = targetOrders.length > 0 ? Math.max(...targetOrders) : -1;
+
+      file.parentId = targetFolderId;
+      file.lastModified = Date.now();
+      file.order = maxOrder + 1;
+
+      if (sourceParentId !== targetFolderId) {
+        const sourceSiblings = this.getFolderSiblings(sourceParentId);
+        sourceSiblings.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+        sourceSiblings.forEach((item, index) => { item.order = index; });
+      }
+
+      await this.saveMetadata();
+      return;
+    }
+
+    // Moving a folder
+    const folder = this.folders.find(f => f.id === itemId);
+    if (folder) {
+      if (targetFolderId && this.isDescendantOf(targetFolderId, itemId)) {
+        throw new Error('Cannot move folder into itself or its subfolders');
+      }
+
+      if (targetFolderId) {
+        const targetDepth = this.getFolderDepth(targetFolderId);
+        const folderDepth = this.getMaxFolderDepth(itemId);
+        if (targetDepth + folderDepth > 5) {
+          throw new Error('Moving this folder would exceed maximum depth (5 levels)');
+        }
+      }
+
+      const sourceParentId = folder.parentId;
+
+      const targetSiblings = this.getFolderSiblings(targetFolderId);
+      const targetOrders = targetSiblings.map(s => s.order).filter((o): o is number => o !== undefined);
+      const maxOrder = targetOrders.length > 0 ? Math.max(...targetOrders) : -1;
+
+      folder.parentId = targetFolderId;
+      folder.updatedAt = Date.now();
+      folder.order = maxOrder + 1;
+
+      if (sourceParentId !== targetFolderId) {
+        const sourceSiblings = this.getFolderSiblings(sourceParentId);
+        sourceSiblings.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+        sourceSiblings.forEach((item, index) => { item.order = index; });
+      }
+
+      await this.saveMetadata();
+    }
+  }
+
+  getFolderDepth(folderId: string): number {
+    let depth = 1;
+    let currentId: string | undefined = folderId;
+
+    while (currentId) {
+      const folder = this.folders.find(f => f.id === currentId);
+      if (folder?.parentId) {
+        depth++;
+        currentId = folder.parentId;
+      } else {
+        currentId = undefined;
+      }
+    }
+
+    return depth;
+  }
+
+  private getMaxFolderDepth(folderId: string): number {
+    let maxDepth = 1;
+
+    const subfolders = this.folders.filter(f => f.parentId === folderId);
+    for (const subfolder of subfolders) {
+      const subfolderDepth = this.getMaxFolderDepth(subfolder.id);
+      maxDepth = Math.max(maxDepth, subfolderDepth + 1);
+    }
+
+    return maxDepth;
+  }
+
+  private isDescendantOf(possibleDescendantId: string, ancestorId: string): boolean {
+    let currentId: string | undefined = possibleDescendantId;
+
+    while (currentId) {
+      if (currentId === ancestorId) {
+        return true;
+      }
+      const folder = this.folders.find(f => f.id === currentId);
+      currentId = folder?.parentId;
+    }
+
+    return false;
+  }
+
+  private getFolderSiblings(parentId?: string): (ScratchpadFolder | ScratchFile)[] {
+    const folders = this.folders.filter(f => f.parentId === parentId);
+    const files = Array.from(this.scratchFiles.values()).filter(f => f.parentId === parentId);
+    return [...folders, ...files];
+  }
+
+  countFolderItems(folderId: string): number {
+    let count = 0;
+
+    count += Array.from(this.scratchFiles.values()).filter(f => f.parentId === folderId).length;
+
+    const subfolders = this.folders.filter(f => f.parentId === folderId);
+    for (const subfolder of subfolders) {
+      count += 1;
+      count += this.countFolderItems(subfolder.id);
+    }
+
+    return count;
+  }
+
+  async reorderItem(draggedId: string, targetId: string, dropPosition: 'before' | 'after'): Promise<void> {
+    const draggedFile = this.scratchFiles.get(draggedId);
+    const draggedFolder = this.folders.find(f => f.id === draggedId);
+    if (!draggedFile && !draggedFolder) {
+      throw new Error('Dragged item not found');
+    }
+
+    const targetFile = this.scratchFiles.get(targetId);
+    const targetFolder = this.folders.find(f => f.id === targetId);
+    if (!targetFile && !targetFolder) {
+      throw new Error('Target item not found');
+    }
+
+    const sourceParentId = draggedFile ? draggedFile.parentId : draggedFolder!.parentId;
+    const targetParentId = targetFile ? targetFile.parentId : targetFolder!.parentId;
+
+    if (draggedFolder && targetParentId !== undefined && this.isDescendantOf(targetParentId, draggedFolder.id)) {
+      throw new Error('Cannot move folder into itself or its subfolders');
+    }
+    if (draggedFolder && targetParentId !== undefined) {
+      const targetDepth = this.getFolderDepth(targetParentId);
+      const folderDepth = this.getMaxFolderDepth(draggedFolder.id);
+      if (targetDepth + folderDepth > 5) {
+        throw new Error('Moving this folder would exceed maximum depth (5 levels)');
+      }
+    }
+
+    // Build ordered list of target parent's items (WITHOUT removing dragged from collections first)
+    // Include ALL items at target parent (target item IS in the list, dragged is EXCLUDED so it can be inserted)
+    const targetFolders = this.folders.filter(f => f.parentId === targetParentId && f.id !== draggedId);
+    const targetFiles = Array.from(this.scratchFiles.values()).filter(f => f.parentId === targetParentId && f.id !== draggedId);
+    const targetItems: Array<ScratchpadFolder | ScratchFile> = [...targetFolders, ...targetFiles]
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+    // Find where to insert relative to the target item
+    const targetIndex = targetItems.findIndex(item => item.id === targetId);
+    const insertIndex = dropPosition === 'after' ? targetIndex + 1 : targetIndex;
+
+    // Insert dragged item at the computed position
+    targetItems.splice(insertIndex, 0, draggedFile ? draggedFile : draggedFolder!);
+
+    // Update order and parentId for ALL target-parent items (includes dragged)
+    targetItems.forEach((item, index) => {
+      const isDraggedFile = item.id === draggedId && draggedFile !== undefined;
+      const isDraggedFolder = item.id === draggedId && draggedFolder !== undefined;
+
+      if (isDraggedFile) {
+        draggedFile.parentId = targetParentId;
+        draggedFile.order = index;
+      } else if (isDraggedFolder) {
+        draggedFolder.parentId = targetParentId;
+        draggedFolder.order = index;
+      } else {
+        const existingFile = this.scratchFiles.get(item.id);
+        if (existingFile) {
+          existingFile.order = index;
+        } else {
+          const existingFolder = this.folders.find(f => f.id === item.id);
+          if (existingFolder) {
+            existingFolder.order = index;
+          }
+        }
+      }
+    });
+
+    // Always update the dragged item's parentId (for cross-parent moves)
+    if (draggedFile) {
+      draggedFile.parentId = targetParentId;
+    } else if (draggedFolder) {
+      draggedFolder.parentId = targetParentId;
+    }
+
+    // If moving between parents, normalize source parent's remaining items
+    if (sourceParentId !== targetParentId) {
+      const sourceFolders = this.folders.filter(f => f.id !== draggedId && f.parentId === sourceParentId);
+      const sourceFiles = Array.from(this.scratchFiles.values()).filter(f => f.id !== draggedId && f.parentId === sourceParentId);
+      const sourceItems: Array<ScratchpadFolder | ScratchFile> = [...sourceFolders, ...sourceFiles]
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      sourceItems.forEach((item, index) => {
+        const existingFile = this.scratchFiles.get(item.id);
+        if (existingFile) {
+          existingFile.order = index;
+        } else {
+          const existingFolder = this.folders.find(f => f.id === item.id);
+          if (existingFolder) {
+            existingFolder.order = index;
+          }
+        }
+      });
+    }
+
+    await this.saveMetadata();
+  }
+
+  async clearAll(): Promise<void> {
+    for (const file of this.scratchFiles.values()) {
+      const filePath = this.getFilePath(file.id);
+      try {
+        const exists = await fs.promises
+          .access(filePath, fs.constants.F_OK)
+          .then(() => true)
+          .catch(() => false);
+        if (exists) {
+          await fs.promises.unlink(filePath);
+        }
+      } catch (error) {
+        console.error(`Failed to delete file ${filePath}:`, error);
+      }
+    }
+
+    this.scratchFiles.clear();
+    this.folders = [];
+    await this.saveMetadata();
   }
 
   getScratchFiles(): ScratchFile[] {
@@ -215,26 +540,6 @@ export class ScratchpadService {
     }
 
     this.scratchFiles.delete(id);
-    await this.saveMetadata();
-  }
-
-  async clearAll(): Promise<void> {
-    for (const file of this.scratchFiles.values()) {
-      const filePath = this.getFilePath(file.id);
-      try {
-        const exists = await fs.promises
-          .access(filePath, fs.constants.F_OK)
-          .then(() => true)
-          .catch(() => false);
-        if (exists) {
-          await fs.promises.unlink(filePath);
-        }
-      } catch (error) {
-        console.error(`Failed to delete file ${filePath}:`, error);
-      }
-    }
-
-    this.scratchFiles.clear();
     await this.saveMetadata();
   }
 

--- a/src/features/scratchpads/ScratchpadValidator.ts
+++ b/src/features/scratchpads/ScratchpadValidator.ts
@@ -1,0 +1,55 @@
+export default class ScratchpadValidator {
+  private static readonly MAX_TOTAL_FILES = 200;
+  private static readonly MIN_FOLDER_NAME_LENGTH = 1;
+  private static readonly MAX_FOLDER_NAME_LENGTH = 75;
+  private static readonly MIN_FILE_NAME_LENGTH = 1;
+  private static readonly MAX_FILE_NAME_LENGTH = 75;
+
+  static validateFolderName(name: string): string | null {
+    if (!name || name.trim().length === 0) {
+      return 'Folder name cannot be empty.';
+    }
+    const trimmed = name.trim();
+    if (trimmed.length < this.MIN_FOLDER_NAME_LENGTH) {
+      return `Folder name must be at least ${this.MIN_FOLDER_NAME_LENGTH} character(s).`;
+    }
+    if (trimmed.length > this.MAX_FOLDER_NAME_LENGTH) {
+      return `Folder name must be no more than ${this.MAX_FOLDER_NAME_LENGTH} characters.`;
+    }
+    if (!/^[a-zA-Z0-9_\-. ]+$/.test(trimmed)) {
+      return 'Folder name contains invalid characters.';
+    }
+    return null;
+  }
+
+  static validateTotalCount(files: { id: string }[]): string | null {
+    if (files.length >= this.MAX_TOTAL_FILES) {
+      return `Maximum of ${this.MAX_TOTAL_FILES} scratchpads reached.`;
+    }
+    return null;
+  }
+
+  static validateFileName(name: string): string | null {
+    if (!name || name.trim().length === 0) {
+      return 'File name cannot be empty.';
+    }
+    const trimmed = name.trim();
+    if (trimmed.length < this.MIN_FILE_NAME_LENGTH) {
+      return `File name must be at least ${this.MIN_FILE_NAME_LENGTH} character(s).`;
+    }
+    if (trimmed.length > this.MAX_FILE_NAME_LENGTH) {
+      return `File name must be no more than ${this.MAX_FILE_NAME_LENGTH} characters.`;
+    }
+    if (!/^[a-zA-Z0-9_\-. ]+$/.test(trimmed)) {
+      return 'File name contains invalid characters.';
+    }
+    return null;
+  }
+
+  static validateForCreate(params: { name?: string; language?: string; content?: string }): string | null {
+    if (params.name !== undefined && params.name !== null) {
+      return this.validateFileName(params.name);
+    }
+    return null;
+  }
+}

--- a/src/features/scratchpads/ScratchpadsProvider.ts
+++ b/src/features/scratchpads/ScratchpadsProvider.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ScratchpadItem } from './views/ScratchpadItem';
+import { ScratchpadFolderTreeItem } from './views/ScratchpadFolderTreeItem';
 import { ScratchpadService } from './ScratchpadService';
+import { ScratchpadFolder } from './Models';
+import ScratchpadValidator from './ScratchpadValidator';
 
 const LANGUAGE_TO_EXTENSION: Record<string, string> = {
   javascript: '.js',
@@ -26,9 +29,11 @@ const LANGUAGE_TO_EXTENSION: Record<string, string> = {
   plaintext: '.txt'
 };
 
-export class ScratchpadsProvider implements vscode.TreeDataProvider<ScratchpadItem> {
-  private _onDidChangeTreeData: vscode.EventEmitter<ScratchpadItem | undefined | null | void> = new vscode.EventEmitter<ScratchpadItem | undefined | null | void>();
-  readonly onDidChangeTreeData: vscode.Event<ScratchpadItem | undefined | null | void> = this._onDidChangeTreeData.event;
+type TreeItem = ScratchpadItem | ScratchpadFolderTreeItem;
+
+export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
+  private _onDidChangeTreeData: vscode.EventEmitter<TreeItem | undefined | null | void> = new vscode.EventEmitter<TreeItem | undefined | null | void>();
+  readonly onDidChangeTreeData: vscode.Event<TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
   public scratchpadService: ScratchpadService;
   private openDocuments: Map<string, vscode.TextDocument> = new Map();
@@ -45,19 +50,80 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<ScratchpadIt
     );
   }
 
-  getTreeItem(element: ScratchpadItem): vscode.TreeItem {
+  getTreeItem(element: TreeItem): vscode.TreeItem {
     return element;
   }
 
-  getChildren(element?: ScratchpadItem): Thenable<ScratchpadItem[]> {
+  getParent(element: TreeItem): TreeItem | undefined {
+    if (element instanceof ScratchpadItem) {
+      const parentId = element.parentId;
+      if (parentId) {
+        const folder = this.scratchpadService.getFolderById(parentId);
+        if (folder) {
+          const depth = this.scratchpadService.getFolderDepth(folder.id);
+          const isAtMaxDepth = depth >= 5;
+          return new ScratchpadFolderTreeItem(folder.name, folder.id, folder.parentId, folder.isExpanded, isAtMaxDepth);
+        }
+      }
+    } else if (element instanceof ScratchpadFolderTreeItem) {
+      if (element.parentId) {
+        const parentFolder = this.scratchpadService.getFolderById(element.parentId);
+        if (parentFolder) {
+          const depth = this.scratchpadService.getFolderDepth(parentFolder.id);
+          const isAtMaxDepth = depth >= 5;
+          return new ScratchpadFolderTreeItem(parentFolder.name, parentFolder.id, parentFolder.parentId, parentFolder.isExpanded, isAtMaxDepth);
+        }
+      }
+    }
+    return undefined;
+  }
+
+  async getChildren(element?: TreeItem): Promise<TreeItem[]> {
+    const folders = this.scratchpadService.getFolders();
+    const allFiles = this.scratchpadService.getScratchFiles();
+
     if (!element) {
-      const items = this.scratchpadService.getScratchFiles()
-        .map(file => new ScratchpadItem(file));
-      return Promise.resolve(items);
+      // Root level
+      const rootFolders = folders
+        .filter(f => !f.parentId)
+        .sort((a, b) => a.order - b.order)
+        .map(folder => {
+          const depth = this.scratchpadService.getFolderDepth(folder.id);
+          const isAtMaxDepth = depth >= 5;
+          return new ScratchpadFolderTreeItem(folder.name, folder.id, folder.parentId, folder.isExpanded, isAtMaxDepth);
+        });
+
+      const rootFiles = allFiles
+        .filter(f => !f.parentId)
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        .map(file => this.createScratchpadItem(file));
+
+      return [...rootFolders, ...rootFiles];
+    } else if (element instanceof ScratchpadFolderTreeItem) {
+      const childFolders = folders
+        .filter(f => f.parentId === element.id)
+        .sort((a, b) => a.order - b.order)
+        .map(folder => {
+          const depth = this.scratchpadService.getFolderDepth(folder.id);
+          const isAtMaxDepth = depth >= 5;
+          return new ScratchpadFolderTreeItem(folder.name, folder.id, folder.parentId, folder.isExpanded, isAtMaxDepth);
+        });
+
+      const childFiles = allFiles
+        .filter(f => f.parentId === element.id)
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        .map(file => this.createScratchpadItem(file));
+
+      return [...childFolders, ...childFiles];
     }
 
-    // For now, we don't support children
-    return Promise.resolve([]);
+    return [];
+  }
+
+  private createScratchpadItem(file: { id: string; name: string; lastModified: number; language?: string; parentId?: string }): ScratchpadItem {
+    const item = new ScratchpadItem(file as any);
+    item.parentId = file.parentId;
+    return item;
   }
 
   refresh(): void {
@@ -66,6 +132,40 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<ScratchpadIt
 
   async reorderScratchpad(draggedId: string, targetId?: string): Promise<void> {
     await this.scratchpadService.reorder(draggedId, targetId);
+    this.refresh();
+  }
+
+  async reorderItem(draggedId: string, targetId: string, dropPosition: 'before' | 'after'): Promise<void> {
+    await this.scratchpadService.reorderItem(draggedId, targetId, dropPosition);
+    this.refresh();
+  }
+
+  async addFolder(name: string, parentId?: string): Promise<ScratchpadFolder> {
+    const error = ScratchpadValidator.validateFolderName(name);
+    if (error) {
+      throw new Error(error);
+    }
+    const folder = await this.scratchpadService.addFolder(name, parentId);
+    this.refresh();
+    return folder;
+  }
+
+  async editFolder(id: string, name: string): Promise<void> {
+    const error = ScratchpadValidator.validateFolderName(name);
+    if (error) {
+      throw new Error(error);
+    }
+    await this.scratchpadService.editFolder(id, name);
+    this.refresh();
+  }
+
+  async deleteFolder(id: string): Promise<void> {
+    await this.scratchpadService.deleteFolder(id);
+    this.refresh();
+  }
+
+  async moveToFolder(itemId: string, targetFolderId?: string): Promise<void> {
+    await this.scratchpadService.moveToFolder(itemId, targetFolderId);
     this.refresh();
   }
 
@@ -122,7 +222,7 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<ScratchpadIt
     return this.scratchpadService.loadFileContent(id);
   }
 
-  async createScratchpadForTools(params: { name?: string; language?: string; content?: string }): Promise<void> {
+  async createScratchpadForTools(params: { name?: string; language?: string; content?: string; parentFolderId?: string }): Promise<void> {
     const extension = this.getExtensionForLanguage(params.language);
     const content = params.content ?? '';
 
@@ -143,6 +243,9 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<ScratchpadIt
     const scratchFile = await this.scratchpadService.createScratchFile(fileName, language);
     if (content.length > 0) {
       await this.scratchpadService.updateFileContent(scratchFile.id, content);
+    }
+    if (params.parentFolderId) {
+      await this.scratchpadService.moveToFolder(scratchFile.id, params.parentFolderId);
     }
     this.refresh();
   }
@@ -172,6 +275,16 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<ScratchpadIt
     }
 
     await this.scratchpadService.renameScratchFile(id, trimmed);
+    this.refresh();
+  }
+
+  async updateScratchpadContentForTools(id: string, content: string): Promise<void> {
+    const file = this.scratchpadService.getScratchFile(id);
+    if (!file) {
+      throw new Error('Scratchpad not found.');
+    }
+
+    await this.scratchpadService.updateFileContent(id, content);
     this.refresh();
   }
 

--- a/src/features/scratchpads/index.ts
+++ b/src/features/scratchpads/index.ts
@@ -2,4 +2,6 @@ export { ScratchpadsProvider } from './ScratchpadsProvider';
 export { registerScratchpadCommands } from './ScratchpadCommands';
 export { registerScratchpadAiTools } from './ScratchpadAiTools';
 export { ScratchpadService } from './ScratchpadService';
+export { default as ScratchpadValidator } from './ScratchpadValidator';
+export { ScratchpadFolderTreeItem } from './views/ScratchpadFolderTreeItem';
 export * from './Models';

--- a/src/features/scratchpads/views/ScratchpadDragAndDropController.ts
+++ b/src/features/scratchpads/views/ScratchpadDragAndDropController.ts
@@ -1,30 +1,40 @@
 import * as vscode from 'vscode';
 import { ScratchpadsProvider } from '../ScratchpadsProvider';
 import { ScratchpadItem } from './ScratchpadItem';
+import { ScratchpadFolderTreeItem } from './ScratchpadFolderTreeItem';
 
-export class ScratchpadDragAndDropController implements vscode.TreeDragAndDropController<ScratchpadItem> {
+type TreeItem = ScratchpadItem | ScratchpadFolderTreeItem;
+
+export class ScratchpadDragAndDropController implements vscode.TreeDragAndDropController<TreeItem> {
   dropMimeTypes = ['application/vnd.code.tree.scratchpadsView'];
   dragMimeTypes = ['text/uri-list'];
 
   constructor(private provider: ScratchpadsProvider) {}
 
   public async handleDrag(
-    source: readonly ScratchpadItem[],
+    source: readonly TreeItem[],
     treeDataTransfer: vscode.DataTransfer,
     token: vscode.CancellationToken
   ): Promise<void> {
     const item = source[0];
-    if (!item?.scratchFile?.id) {
+    if (!item) {
       return;
     }
+
+    const isFolder = item instanceof ScratchpadFolderTreeItem;
+    const id = isFolder ? (item as ScratchpadFolderTreeItem).id : (item as ScratchpadItem).scratchFile?.id;
+    if (!id) {
+      return;
+    }
+
     treeDataTransfer.set(
       'application/vnd.code.tree.scratchpadsView',
-      new vscode.DataTransferItem(JSON.stringify({ id: item.scratchFile.id }))
+      new vscode.DataTransferItem(JSON.stringify({ id, isFolder }))
     );
   }
 
   public async handleDrop(
-    target: ScratchpadItem | undefined,
+    target: TreeItem | undefined,
     sources: vscode.DataTransfer,
     token: vscode.CancellationToken
   ): Promise<void> {
@@ -36,16 +46,54 @@ export class ScratchpadDragAndDropController implements vscode.TreeDragAndDropCo
     try {
       const dragData = JSON.parse(transferItem.value);
       const draggedId: string | undefined = dragData.id;
+      const isDraggedFolder: boolean = dragData.isFolder;
       if (!draggedId) {
         return;
       }
 
-      const targetId = target?.scratchFile?.id;
-      if (targetId === draggedId) {
+      // Determine target folder ID
+      let targetFolderId: string | undefined;
+      if (target instanceof ScratchpadFolderTreeItem) {
+        targetFolderId = (target as ScratchpadFolderTreeItem).id;
+      } else if (target instanceof ScratchpadItem) {
+        // Dropping on a file → reorder within same folder
+        targetFolderId = target.parentId;
+      }
+      // Dropping on empty space (target is undefined) → move to root
+
+      // If dropping on a folder at max depth, reject folder moves
+      if (target instanceof ScratchpadFolderTreeItem && isDraggedFolder && (target as ScratchpadFolderTreeItem).isAtMaxDepth) {
         return;
       }
 
-      await this.provider.reorderScratchpad(draggedId, targetId);
+      const draggedFile = this.provider.scratchpadService.getScratchFile(draggedId);
+      const draggedFolder = this.provider.scratchpadService.getFolderById(draggedId);
+
+      if (draggedFile) {
+        // Dropping a file
+        if (target instanceof ScratchpadFolderTreeItem) {
+          // Move to folder
+          await this.provider.moveToFolder(draggedId, targetFolderId);
+        } else if (target instanceof ScratchpadItem) {
+          // Reorder relative to target file (dropping before the target)
+          await this.provider.reorderItem(draggedId, target.scratchFile.id, 'before');
+        } else {
+          // Drop on empty space → move to root
+          await this.provider.moveToFolder(draggedId, undefined);
+        }
+      } else if (draggedFolder) {
+        // Dropping a folder
+        if (target instanceof ScratchpadFolderTreeItem) {
+          // Move folder into target folder
+          await this.provider.moveToFolder(draggedId, targetFolderId);
+        } else if (target instanceof ScratchpadItem) {
+          // Move folder to same parent as target file (reorder)
+          await this.provider.moveToFolder(draggedId, target.parentId);
+        } else {
+          // Drop on empty space → move to root
+          await this.provider.moveToFolder(draggedId, undefined);
+        }
+      }
     } catch (error) {
       console.error('Error handling scratchpad drop:', error);
     }

--- a/src/features/scratchpads/views/ScratchpadFolderTreeItem.ts
+++ b/src/features/scratchpads/views/ScratchpadFolderTreeItem.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+export class ScratchpadFolderTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly id: string,
+    public readonly parentId?: string,
+    public readonly isExpanded?: boolean,
+    public readonly isAtMaxDepth: boolean = false
+  ) {
+    super(label, isExpanded ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed);
+
+    this.iconPath = new vscode.ThemeIcon('folder');
+
+    this.contextValue = isAtMaxDepth ? 'scratchpadFolderMaxDepth' : 'scratchpadFolder';
+
+    this.id = id;
+  }
+}

--- a/src/features/scratchpads/views/ScratchpadItem.ts
+++ b/src/features/scratchpads/views/ScratchpadItem.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { ScratchFile } from '../Models';
 
 export class ScratchpadItem extends vscode.TreeItem {
+  public parentId?: string;
+
   constructor(
     public readonly scratchFile: ScratchFile
   ) {

--- a/src/test/features/scratchpad-service-folders.test.ts
+++ b/src/test/features/scratchpad-service-folders.test.ts
@@ -1,0 +1,317 @@
+import * as assert from 'assert';
+import { ScratchpadService } from '../../features/scratchpads/ScratchpadService';
+import { createMockExtensionContext } from '../testUtils';
+
+suite('ScratchpadService - folders', () => {
+  let mockContext: any;
+  let service: ScratchpadService;
+
+  setup(async () => {
+    mockContext = createMockExtensionContext();
+    service = new ScratchpadService(mockContext);
+    await service.loadScratchFiles();
+  });
+
+  teardown(() => {
+    const fs = require('fs');
+    const path = require('path');
+    const tempRoot = path.dirname(mockContext.globalStorageUri.fsPath);
+    try {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  suite('folder CRUD', () => {
+    test('addFolder creates a folder at root', async () => {
+      const folder = await service.addFolder('Work');
+      assert.strictEqual(folder.name, 'Work');
+      assert.strictEqual(folder.parentId, undefined);
+      assert.ok(folder.id);
+      assert.ok(folder.createdAt);
+      assert.ok(folder.updatedAt);
+    });
+
+    test('addFolder creates a subfolder under a parent', async () => {
+      const parent = await service.addFolder('Parent');
+      const child = await service.addFolder('Child', parent.id);
+      assert.strictEqual(child.name, 'Child');
+      assert.strictEqual(child.parentId, parent.id);
+    });
+
+    test('addFolder assigns order sequentially', async () => {
+      const f1 = await service.addFolder('Folder 1');
+      const f2 = await service.addFolder('Folder 2');
+      const f3 = await service.addFolder('Folder 3');
+      assert.strictEqual(f1.order, 0);
+      assert.strictEqual(f2.order, 1);
+      assert.strictEqual(f3.order, 2);
+    });
+
+    test('editFolder updates name', async () => {
+      const folder = await service.addFolder('Old Name');
+      await service.editFolder(folder.id, 'New Name');
+      const updated = service.getFolderById(folder.id);
+      assert.strictEqual(updated?.name, 'New Name');
+    });
+
+    test('editFolder trims whitespace', async () => {
+      const folder = await service.addFolder('Folder');
+      await service.editFolder(folder.id, '  trimmed  ');
+      assert.strictEqual(service.getFolderById(folder.id)?.name, 'trimmed');
+    });
+
+    test('deleteFolder removes the folder', async () => {
+      const folder = await service.addFolder('To Delete');
+      await service.deleteFolder(folder.id);
+      assert.strictEqual(service.getFolderById(folder.id), undefined);
+    });
+
+    test('deleteFolder is recursive - deletes subfolders', async () => {
+      const p = await service.addFolder('Parent');
+      const c = await service.addFolder('Child', p.id);
+      const gc = await service.addFolder('GrandChild', c.id);
+      await service.deleteFolder(p.id);
+      assert.strictEqual(service.getFolderById(p.id), undefined);
+      assert.strictEqual(service.getFolderById(c.id), undefined);
+      assert.strictEqual(service.getFolderById(gc.id), undefined);
+    });
+
+    test('deleteFolder moves contained files to root', async () => {
+      const folder = await service.addFolder('Folder');
+      const file = await service.createScratchFile('test.txt');
+      await service.moveToFolder(file.id, folder.id);
+      await service.deleteFolder(folder.id);
+      const movedFile = service.getScratchFile(file.id);
+      assert.strictEqual(movedFile?.parentId, undefined);
+    });
+  });
+
+  suite('getFolderDepth', () => {
+    test('returns 1 for root folder', async () => {
+      const f = await service.addFolder('Root');
+      assert.strictEqual(service.getFolderDepth(f.id), 1);
+    });
+
+    test('returns 2 for folder nested one level deep', async () => {
+      const p = await service.addFolder('Parent');
+      const c = await service.addFolder('Child', p.id);
+      assert.strictEqual(service.getFolderDepth(c.id), 2);
+    });
+
+    test('returns correct depth for deeply nested folder', async () => {
+      const l1 = await service.addFolder('L1');
+      const l2 = await service.addFolder('L2', l1.id);
+      const l3 = await service.addFolder('L3', l2.id);
+      const l4 = await service.addFolder('L4', l3.id);
+      const l5 = await service.addFolder('L5', l4.id);
+      assert.strictEqual(service.getFolderDepth(l5.id), 5);
+    });
+  });
+
+  suite('moveToFolder', () => {
+    test('moves file from root to folder', async () => {
+      const folder = await service.addFolder('Folder');
+      const file = await service.createScratchFile('test.txt');
+      await service.moveToFolder(file.id, folder.id);
+      const moved = service.getScratchFile(file.id);
+      assert.strictEqual(moved?.parentId, folder.id);
+    });
+
+    test('moves file from folder to root', async () => {
+      const folder = await service.addFolder('Folder');
+      const file = await service.createScratchFile('test.txt');
+      await service.moveToFolder(file.id, folder.id);
+      await service.moveToFolder(file.id, undefined);
+      const moved = service.getScratchFile(file.id);
+      assert.strictEqual(moved?.parentId, undefined);
+    });
+
+    test('moves folder to another folder (within depth limit)', async () => {
+      const p1 = await service.addFolder('P1');
+      const p2 = await service.addFolder('P2');
+      const child = await service.addFolder('Child', p1.id);
+      await service.moveToFolder(child.id, p2.id);
+      const moved = service.getFolderById(child.id);
+      assert.strictEqual(moved?.parentId, p2.id);
+    });
+
+    test('throws when moving folder into itself', async () => {
+      const folder = await service.addFolder('Folder');
+      await assert.rejects(
+        () => service.moveToFolder(folder.id, folder.id),
+        /Cannot move folder into itself or its subfolders/
+      );
+    });
+
+    test('throws when moving folder into its descendant', async () => {
+      const parent = await service.addFolder('Parent');
+      const child = await service.addFolder('Child', parent.id);
+      await assert.rejects(
+        () => service.moveToFolder(parent.id, child.id),
+        /Cannot move folder into itself or its subfolders/
+      );
+    });
+
+    test('throws when moving folder would exceed max depth (5)', async () => {
+      // Build two parallel chains so that we don't trigger isDescendantOf
+      // Chain 1: l1 -> l2 -> l3 -> l4 (depth 4 at l4)
+      const l1 = await service.addFolder('L1');
+      const l2 = await service.addFolder('L2', l1.id);
+      const l3 = await service.addFolder('L3', l2.id);
+      const l4 = await service.addFolder('L4', l3.id);
+      // Chain 2: r1 -> r2 (depth 2 at r2)
+      const r1 = await service.addFolder('R1');
+      const r2 = await service.addFolder('R2', r1.id);
+      // l4 is at depth 4, r2 is at depth 2
+      // moveToFolder(l1, r2) -> targetDepth(r2)=2 + maxFolderDepth(l1)=4 = 6 > 5
+      await assert.rejects(
+        () => service.moveToFolder(l1.id, r2.id),
+        /exceed maximum depth.*5 levels/
+      );
+    });
+
+    test('moveToFolder normalizes source sibling order after removal', async () => {
+      const f1 = await service.addFolder('F1');
+      const f2 = await service.addFolder('F2');
+      const f3 = await service.addFolder('F3');
+      const folder = await service.addFolder('Folder');
+      // Move f1 into folder
+      await service.moveToFolder(f1.id, folder.id);
+      // f2 and f3 should re-normalize to orders 0 and 1
+      const f2Updated = service.getFolderById(f2.id);
+      const f3Updated = service.getFolderById(f3.id);
+      assert.strictEqual(f2Updated?.order, 0);
+      assert.strictEqual(f3Updated?.order, 1);
+    });
+  });
+
+  suite('isDescendantOf', () => {
+    // Expose via moveToFolder throws which use it internally
+    test('returns true for direct child', async () => {
+      const p = await service.addFolder('Parent');
+      const c = await service.addFolder('Child', p.id);
+      await assert.rejects(
+        () => service.moveToFolder(p.id, c.id),
+        /Cannot move folder into itself or its subfolders/
+      );
+    });
+
+    test('returns true for nested descendant', async () => {
+      const p = await service.addFolder('Parent');
+      const c = await service.addFolder('Child', p.id);
+      const gc = await service.addFolder('GrandChild', c.id);
+      await assert.rejects(
+        () => service.moveToFolder(p.id, gc.id),
+        /Cannot move folder into itself or its subfolders/
+      );
+    });
+  });
+
+  suite('countFolderItems', () => {
+    test('returns 0 for empty folder', async () => {
+      const folder = await service.addFolder('Empty');
+      assert.strictEqual(service.countFolderItems(folder.id), 0);
+    });
+
+    test('counts direct files in folder', async () => {
+      const folder = await service.addFolder('Folder');
+      await service.createScratchFile('f1.txt');
+      await service.createScratchFile('f2.txt');
+      await service.createScratchFile('f3.txt');
+      const files = service.getScratchFiles();
+      for (const f of files) {
+        await service.moveToFolder(f.id, folder.id);
+      }
+      assert.strictEqual(service.countFolderItems(folder.id), 3);
+    });
+
+    test('counts nested subfolder and its contents', async () => {
+      const parent = await service.addFolder('Parent');
+      const child = await service.addFolder('Child', parent.id);
+      const file = await service.createScratchFile('file.txt');
+      await service.moveToFolder(file.id, child.id);
+      // Child folder itself counts as 1, plus 1 file inside
+      assert.strictEqual(service.countFolderItems(parent.id), 2);
+    });
+  });
+
+  suite('reorderItem', () => {
+    test('reorders files within same parent (root)', async () => {
+      const f1 = await service.createScratchFile('file1.txt');
+      const f2 = await service.createScratchFile('file2.txt');
+      const f3 = await service.createScratchFile('file3.txt');
+      await service.reorderItem(f3.id, f1.id, 'before');
+      const files = service.getScratchFiles();
+      assert.strictEqual(files[0].id, f3.id);
+      assert.strictEqual(files[1].id, f1.id);
+      assert.strictEqual(files[2].id, f2.id);
+    });
+
+    test('reorders folders within same parent', async () => {
+      const f1 = await service.addFolder('F1');
+      const f2 = await service.addFolder('F2');
+      const f3 = await service.addFolder('F3');
+      // f1=0, f2=1, f3=2 → reorder f3 before f1 → f3=0, f1=1, f2=2
+      await service.reorderItem(f3.id, f1.id, 'before');
+      const allFolders = service.getFolders();
+      const f1After = allFolders.find(f => f.id === f1.id)!;
+      const f2After = allFolders.find(f => f.id === f2.id)!;
+      const f3After = allFolders.find(f => f.id === f3.id)!;
+      assert.strictEqual(f3After.order, 0);
+      assert.strictEqual(f1After.order, 1);
+      assert.strictEqual(f2After.order, 2);
+    });
+
+    test('reorderItem updates dragged folder order when target is in different parent', async () => {
+      // reorderItem with cross-parent: child folder moves from p1 to p2's parent level
+      // and both get normalized orders in their respective parents
+      const p1 = await service.addFolder('P1');
+      const p2 = await service.addFolder('P2');
+      const child = await service.addFolder('Child', p1.id);
+      // Move child out of p1 and to the root level (same as p2)
+      await service.reorderItem(child.id, p2.id, 'after');
+      const moved = service.getFolderById(child.id);
+      // child should now be at root level (parentId = undefined), same as p2
+      assert.strictEqual(moved?.parentId, undefined);
+    });
+
+    test('reorderItem throws when moving folder into its own descendant', async () => {
+      const parent = await service.addFolder('Parent');
+      const child = await service.addFolder('Child', parent.id);
+      await assert.rejects(
+        () => service.reorderItem(parent.id, child.id, 'after'),
+        /Cannot move folder into itself or its subfolders/
+      );
+    });
+  });
+
+  suite('clearAll', () => {
+    test('clears all folders along with files', async () => {
+      const folder = await service.addFolder('Folder');
+      const file = await service.createScratchFile('file.txt');
+      await service.moveToFolder(file.id, folder.id);
+      await service.clearAll();
+      assert.strictEqual(service.getFolders().length, 0);
+      assert.strictEqual(service.getScratchFiles().length, 0);
+    });
+  });
+
+  suite('getFolderSiblings', () => {
+    test('moveToFolder with undefined moves folder to root', async () => {
+      const folder = await service.addFolder('Folder');
+      await service.moveToFolder(folder.id, undefined);
+      const moved = service.getFolderById(folder.id);
+      assert.strictEqual(moved?.parentId, undefined);
+    });
+
+    test('files moved to folder have correct parentId', async () => {
+      const folder = await service.addFolder('Folder');
+      const file = await service.createScratchFile('file.txt');
+      await service.moveToFolder(file.id, folder.id);
+      const moved = service.getScratchFile(file.id);
+      assert.strictEqual(moved?.parentId, folder.id);
+    });
+  });
+});

--- a/src/test/features/scratchpad-validator.test.ts
+++ b/src/test/features/scratchpad-validator.test.ts
@@ -1,0 +1,137 @@
+import * as assert from 'assert';
+import ScratchpadValidator from '../../features/scratchpads/ScratchpadValidator';
+
+suite('ScratchpadValidator', () => {
+  suite('validateFolderName', () => {
+    test('returns null for valid folder name', () => {
+      assert.strictEqual(ScratchpadValidator.validateFolderName('My Folder'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('work'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('a'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_- .'), null);
+    });
+
+    test('returns error for empty string', () => {
+      assert.strictEqual(ScratchpadValidator.validateFolderName(''), 'Folder name cannot be empty.');
+      assert.strictEqual(ScratchpadValidator.validateFolderName('   '), 'Folder name cannot be empty.');
+    });
+
+    test('returns error for name exceeding 75 characters', () => {
+      const longName = 'a'.repeat(76);
+      assert.strictEqual(
+        ScratchpadValidator.validateFolderName(longName),
+        'Folder name must be no more than 75 characters.'
+      );
+    });
+
+    test('returns null for name at exactly 75 characters', () => {
+      const maxName = 'a'.repeat(75);
+      assert.strictEqual(ScratchpadValidator.validateFolderName(maxName), null);
+    });
+
+    test('returns error for invalid characters', () => {
+      assert.strictEqual(
+        ScratchpadValidator.validateFolderName('folder@name'),
+        'Folder name contains invalid characters.'
+      );
+      assert.strictEqual(
+        ScratchpadValidator.validateFolderName('folder/name'),
+        'Folder name contains invalid characters.'
+      );
+      assert.strictEqual(
+        ScratchpadValidator.validateFolderName('folder\\name'),
+        'Folder name contains invalid characters.'
+      );
+      assert.strictEqual(
+        ScratchpadValidator.validateFolderName('folder:name'),
+        'Folder name contains invalid characters.'
+      );
+    });
+
+    test('allows valid special characters: dash, underscore, space, dot, hyphen', () => {
+      assert.strictEqual(ScratchpadValidator.validateFolderName('my-folder'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('my_folder'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('my folder'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('my.folder'), null);
+      assert.strictEqual(ScratchpadValidator.validateFolderName('my folder-2024_v1.0'), null);
+    });
+
+    test('trims whitespace before validation', () => {
+      assert.strictEqual(ScratchpadValidator.validateFolderName('  my folder  '), null);
+    });
+  });
+
+  suite('validateTotalCount', () => {
+    test('returns null when under limit', () => {
+      const files = Array.from({ length: 100 }, (_, i) => ({ id: `file-${i}` }));
+      assert.strictEqual(ScratchpadValidator.validateTotalCount(files), null);
+    });
+
+    test('returns null when at exactly 199 files', () => {
+      const files = Array.from({ length: 199 }, (_, i) => ({ id: `file-${i}` }));
+      assert.strictEqual(ScratchpadValidator.validateTotalCount(files), null);
+    });
+
+    test('returns error when at 200 files (limit reached)', () => {
+      const files = Array.from({ length: 200 }, (_, i) => ({ id: `file-${i}` }));
+      assert.strictEqual(
+        ScratchpadValidator.validateTotalCount(files),
+        'Maximum of 200 scratchpads reached.'
+      );
+    });
+
+    test('returns error when over limit', () => {
+      const files = Array.from({ length: 201 }, (_, i) => ({ id: `file-${i}` }));
+      assert.strictEqual(
+        ScratchpadValidator.validateTotalCount(files),
+        'Maximum of 200 scratchpads reached.'
+      );
+    });
+  });
+
+  suite('validateFileName', () => {
+    test('returns null for valid file name', () => {
+      assert.strictEqual(ScratchpadValidator.validateFileName('file.txt'), null);
+      assert.strictEqual(ScratchpadValidator.validateFileName('my file.js'), null);
+    });
+
+    test('returns error for empty string', () => {
+      assert.strictEqual(ScratchpadValidator.validateFileName(''), 'File name cannot be empty.');
+      assert.strictEqual(ScratchpadValidator.validateFileName('   '), 'File name cannot be empty.');
+    });
+
+    test('returns error for name exceeding 75 characters', () => {
+      const longName = 'a'.repeat(76);
+      assert.strictEqual(
+        ScratchpadValidator.validateFileName(longName),
+        'File name must be no more than 75 characters.'
+      );
+    });
+
+    test('returns error for invalid characters', () => {
+      assert.strictEqual(
+        ScratchpadValidator.validateFileName('file@name'),
+        'File name contains invalid characters.'
+      );
+      assert.strictEqual(
+        ScratchpadValidator.validateFileName('file/name'),
+        'File name contains invalid characters.'
+      );
+    });
+  });
+
+  suite('validateForCreate', () => {
+    test('returns null when name is undefined', () => {
+      assert.strictEqual(ScratchpadValidator.validateForCreate({}), null);
+      assert.strictEqual(ScratchpadValidator.validateForCreate({ language: 'js' }), null);
+    });
+
+    test('validates file name when provided', () => {
+      assert.strictEqual(ScratchpadValidator.validateForCreate({ name: '' }), 'File name cannot be empty.');
+      assert.strictEqual(
+        ScratchpadValidator.validateForCreate({ name: 'a'.repeat(76) }),
+        'File name must be no more than 75 characters.'
+      );
+      assert.strictEqual(ScratchpadValidator.validateForCreate({ name: 'valid.js' }), null);
+    });
+  });
+});

--- a/src/test/integration/ai-tools-registration.test.ts
+++ b/src/test/integration/ai-tools-registration.test.ts
@@ -44,8 +44,12 @@ suite('AI tools registration', () => {
       'codebench_get_scratchpads',
       'codebench_get_scratchpad_content',
       'codebench_create_scratchpad',
+      'codebench_update_scratchpad_content',
       'codebench_rename_scratchpad',
-      'codebench_delete_scratchpad'
+      'codebench_delete_scratchpad',
+      'codebench_create_scratchpad_folder',
+      'codebench_move_scratchpad_to_folder',
+      'codebench_delete_scratchpad_folder'
     ];
 
     const registeredToolNames = new Set(vscode.lm.tools.map(tool => tool.name));


### PR DESCRIPTION
This pull request introduces comprehensive support for organizing scratchpads into folders, along with several new language model tools and commands for managing scratchpad files and folders. It also updates the data model and business rules to accommodate these new features. Below are the most important changes:

**Scratchpad Folders Feature:**

* Added a new `ScratchpadFolder` interface and updated `ScratchpadData` to support nested folders; each scratchpad file can now have a `parentId` referencing its folder. (`src/features/scratchpads/Models.ts`, [src/features/scratchpads/Models.tsR9-R28](diffhunk://#diff-d39a8df95eec8100a73e82da51f0c292c90c620b8583e0799e8f41030d5bf413R9-R28))
* Updated the scratchpad version to 2 to reflect the new folder structure. (`src/features/scratchpads/Models.ts`, [src/features/scratchpads/Models.tsR9-R28](diffhunk://#diff-d39a8df95eec8100a73e82da51f0c292c90c620b8583e0799e8f41030d5bf413R9-R28))

**Language Model Tools Expansion:**

* Added four new scratchpad folder tools: create, move, and delete folders, and move scratchpads into folders. Also added a tool for updating scratchpad content. All tools are registered and described in `package.json` and `ScratchpadAiTools.ts`. (`package.json`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R477-R503) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R550-R614); `src/features/scratchpads/ScratchpadAiTools.ts`, [[3]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR18-R48) [[4]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR168-R192) [[5]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR226-R289) [[6]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR298-R303)
* Updated the `get_scratchpads` tool to return both files and folders, and to support filtering by folder. (`src/features/scratchpads/ScratchpadAiTools.ts`, [[1]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR7) [[2]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR62-R89) [[3]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR102-R108) [[4]](diffhunk://#diff-78c3a372ca6fbaeea2f6f683cb2cd3a610363dda319a5ec1c0719e8a617c8b4eR119-R124); `package.json`, [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R428-R431)

**Commands and UI Integration:**

* Added new VS Code commands for adding, editing, and deleting scratchpad folders, with corresponding context menu and view integration. (`package.json`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R195-R218) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R697-R701) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R769-R783)

**Documentation and Business Rules:**

* Updated `AGENTS.md` to document the new folder structure, expanded tool list (now 9 scratchpad tools), and new business rules (e.g., max 200 files, folder depth up to 5 levels). (`AGENTS.md`, [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L57-R63) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L98-R100) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R150)

**Validation and Structure:**

* Introduced `ScratchpadValidator` for input validation (file/folder names, count limits), referenced in the folder structure documentation. (`AGENTS.md`, [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L57-R63); `src/features/scratchpads/ScratchpadCommands.ts`, [[2]](diffhunk://#diff-716838c81a449b05ed3e004515a23aec2d90df38a6fe8dbba56980d6f9e8270fR3)

These changes lay the foundation for hierarchical organization of scratchpads, improve the language model's ability to interact with scratchpads and folders, and update both the extension's UI and data model accordingly.