### PR TITLE
Release 1.3.0: scratchpad import, virtual storage, and folder tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — VS CodeBench
 
 ## Project Overview
-VS CodeBench is a VS Code extension (TypeScript) that provides three productivity features in a single sidebar panel: hierarchical **Todos**, line-level **Bookmarks** (with color & folders), and persistent **Scratchpads**. It also exposes GitHub Copilot language model tools for bookmark and scratchpad operations. All data is scoped to the active workspace via VS Code's `Memento` storage API.
+VS CodeBench is a VS Code extension (TypeScript) that provides three productivity features in a single sidebar panel: hierarchical **Todos**, line-level **Bookmarks** (with color & folders), and persistent **Scratchpads**. It also exposes GitHub Copilot language model tools for bookmark and scratchpad operations. Todo and bookmark data, plus scratchpad metadata, are workspace-scoped via VS Code's `Memento` storage API; scratchpad file contents are stored as extension-managed backing files under the workspace/global storage directory.
 
 - **Publisher:** `nazariitaran`
 - **Extension ID:** `nazariitaran.vs-codebench`
@@ -56,6 +56,7 @@ src/
 │   └── scratchpads/
 │       ├── Models.ts             # ScratchFile, ScratchpadFolder, ScratchpadData interfaces
 │       ├── ScratchpadAiTools.ts  # GitHub Copilot language model tools (9 tools)
+│       ├── ScratchpadFileSystemProvider.ts  # Custom writable provider for codebench-scratchpad URIs
 │       ├── ScratchpadService.ts
 │       ├── ScratchpadValidator.ts # Input validation (file/folder name, count limits)
 │       ├── ScratchpadCommands.ts
@@ -84,13 +85,17 @@ Each feature (`todos`, `bookmarks`, `scratchpads`) follows the same layered stru
 6. **views/** — `TreeItem` subclasses, `DragAndDropController` implementations
 7. **index.ts** — barrel file re-exporting public API
 
+Scratchpads additionally include `ScratchpadFileSystemProvider.ts`, which exposes scratchpads through the custom `codebench-scratchpad` scheme so editor-facing names stay logical while disk file names remain internal.
+
 ### Storage
 - `StorageService` wraps VS Code's `Memento` API with scope detection (`workspace` / `global` / `auto`)
 - `NamespacedStorageService` extends it with deterministic key generation: `{feature}::{workspaceUri}::{subKey}`
 - Each service creates its own namespaced storage: `createNamespacedStorage(context, 'todos')`
+- Scratchpad metadata is stored in the scratchpads namespace, while scratchpad bodies live in extension-managed backing files under `<storage>/scratchpads/`
+- Scratchpad steady-state metadata does not store file content; legacy `content` fields are migration-only input for v3 upgrades
 
 ### Extension Lifecycle
-- `activate()` creates three Providers, three TreeViews with DnD controllers, registers all feature commands, and registers GitHub Copilot tools for bookmarks/scratchpads
+- `activate()` creates three Providers, three TreeViews with DnD controllers, registers all feature commands, registers a writable `codebench-scratchpad` FileSystemProvider, and registers GitHub Copilot tools for bookmarks/scratchpads
 - `activate()` returns `{ todosProvider, bookmarksProvider, scratchpadsProvider }` for test access
 - All disposables go into `context.subscriptions`
 
@@ -147,7 +152,7 @@ Tests require a VS Code instance (Extension Host). On headless CI, `xvfb-run` is
 ## Business Rules & Limits
 - Todos: max 100 total items, max 2 levels of nesting (parent → child → grandchild), text 1–75 chars
 - Bookmarks: max 200 items, folder depth up to 3 levels, bookmark text 1–75 chars, folder name 1–75 chars
-- Scratchpads: max 200 files, folder depth up to 5 levels, file text 1–75 chars, folder name 1–75 chars
+- Scratchpads: max 400 files, folder depth up to 5 levels, file text 1–75 chars, folder name 1–75 chars
 - Bookmark colors: `default` (blue), `red`, `green`, `yellow`, `purple`
 - All commands are prefixed with `vs-codebench.`
 
@@ -170,3 +175,5 @@ Tests require a VS Code instance (Extension Host). On headless CI, `xvfb-run` is
 - When adding new commands, also update `contributes.menus` in `package.json` for proper visibility in tree views and context menus.
 - `vs-codebench.saveUnsavedAsScratchpad` is available only for `resourceScheme == 'untitled'` in the editor context menu.
 - When adding/changing Copilot tools, keep `contributes.languageModelTools` in sync with `BookmarkAiTools.ts` and `ScratchpadAiTools.ts`.
+- Scratchpad editor flows should open `codebench-scratchpad` URIs via `ScratchpadService.getScratchpadUri()` or `ScratchpadsProvider.openScratchFile()` instead of raw `file:` URIs.
+- Scratchpad folder deletion is recursive after user confirmation; do not reparent deleted folder contents back to the root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,8 @@ src/
 │   │       └── BookmarkDragAndDropController.ts
 │   └── scratchpads/
 │       ├── Models.ts             # ScratchFile, ScratchpadFolder, ScratchpadData interfaces
-│       ├── ScratchpadAiTools.ts  # GitHub Copilot language model tools (9 tools)
-│       ├── ScratchpadFileSystemProvider.ts  # Custom writable provider for codebench-scratchpad URIs
+│       ├── ScratchpadAiTools.ts  # GitHub Copilot language model tools (11 tools, folder-aware)
+│       ├── ScratchpadFileSystemProvider.ts  # Custom writable provider for codebench-scratchpad URIs; waits for provider readiness during restore/startup
 │       ├── ScratchpadService.ts
 │       ├── ScratchpadValidator.ts # Input validation (file/folder name, count limits)
 │       ├── ScratchpadCommands.ts
@@ -85,7 +85,7 @@ Each feature (`todos`, `bookmarks`, `scratchpads`) follows the same layered stru
 6. **views/** — `TreeItem` subclasses, `DragAndDropController` implementations
 7. **index.ts** — barrel file re-exporting public API
 
-Scratchpads additionally include `ScratchpadFileSystemProvider.ts`, which exposes scratchpads through the custom `codebench-scratchpad` scheme so editor-facing names stay logical while disk file names remain internal.
+Scratchpads additionally include `ScratchpadFileSystemProvider.ts`, which exposes scratchpads through the custom `codebench-scratchpad` scheme so editor-facing names stay logical while disk file names remain internal. The provider now waits for scratchpad metadata loading before serving file-system operations triggered during startup or editor restore.
 
 ### Storage
 - `StorageService` wraps VS Code's `Memento` API with scope detection (`workspace` / `global` / `auto`)
@@ -102,7 +102,9 @@ Scratchpads additionally include `ScratchpadFileSystemProvider.ts`, which expose
 ### GitHub Copilot Tools
 - Tools are contributed via `package.json` → `contributes.languageModelTools` and registered with `vscode.lm.registerTool(...)`.
 - Bookmark tools (8): `codebench_get_bookmarks`, `codebench_add_bookmark`, `codebench_move_bookmark_to_folder`, `codebench_rename_bookmark`, `codebench_set_bookmark_color`, `codebench_remove_bookmark`, `codebench_create_bookmark_folder`, `codebench_remove_bookmark_folder`.
-- Scratchpad tools (9): `codebench_get_scratchpads`, `codebench_get_scratchpad_content`, `codebench_create_scratchpad`, `codebench_update_scratchpad_content`, `codebench_rename_scratchpad`, `codebench_delete_scratchpad`, `codebench_create_scratchpad_folder`, `codebench_move_scratchpad_to_folder`, `codebench_delete_scratchpad_folder`.
+- Scratchpad tools (11): `codebench_get_scratchpads`, `codebench_get_scratchpad_content`, `codebench_create_scratchpad`, `codebench_update_scratchpad_content`, `codebench_rename_scratchpad`, `codebench_delete_scratchpad`, `codebench_create_scratchpad_folder`, `codebench_rename_scratchpad_folder`, `codebench_move_scratchpad_to_folder`, `codebench_move_scratchpad_folder`, `codebench_delete_scratchpad_folder`.
+- `codebench_get_scratchpads` defaults to root-level scratchpads when `folderId` is omitted, but it returns folder metadata and supports `includeAll: true` for workspace-wide listing.
+- Scratchpad move tools support moving scratchpads or folders back to root by omitting the destination folder id.
 - Tool outputs are JSON text payloads wrapped in `LanguageModelToolResult`.
 
 ## Build & Development Commands
@@ -170,10 +172,12 @@ Tests require a VS Code instance (Extension Host). On headless CI, `xvfb-run` is
 - The `out/` directory is gitignored build output — never edit files there.
 - When adding a new feature, follow the existing module pattern: Models → Service → Validator → Commands → Provider → views/ → index.ts barrel.
 - Storage keys are workspace-scoped by default — be careful with `'auto'` scope behavior.
-- The extension activates on `onStartupFinished` — it is always active once VS Code loads.
+- The extension activates on `onStartupFinished` and `onFileSystem:codebench-scratchpad` so restored scratchpad editors can resolve before normal startup activation completes.
 - All command IDs are defined in `package.json` under `contributes.commands` — keep them in sync with `{Feature}Commands.ts`.
 - When adding new commands, also update `contributes.menus` in `package.json` for proper visibility in tree views and context menus.
+- Scratchpad folder rows expose a dedicated `vs-codebench.createScratchpadInFolder` action for creating a new scratchpad directly inside the selected folder.
 - `vs-codebench.saveUnsavedAsScratchpad` is available only for `resourceScheme == 'untitled'` in the editor context menu.
 - When adding/changing Copilot tools, keep `contributes.languageModelTools` in sync with `BookmarkAiTools.ts` and `ScratchpadAiTools.ts`.
 - Scratchpad editor flows should open `codebench-scratchpad` URIs via `ScratchpadService.getScratchpadUri()` or `ScratchpadsProvider.openScratchFile()` instead of raw `file:` URIs.
+- Scratchpad file-system operations that can run during startup/restore should wait on `ScratchpadsProvider.whenReady()` before reading or mutating scratchpad state.
 - Scratchpad folder deletion is recursive after user confirmation; do not reparent deleted folder contents back to the root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.3.0 - May 2026
+
+- Added a scratchpad import workflow that can ingest a folder tree, preserve structure, skip binary files and symlinks, overwrite matching scratchpads in place, and generate an import summary scratchpad.
+- Refactored scratchpads onto a dedicated `codebench-scratchpad` file system so logical names and folder paths stay stable even when backing files are renamed or migrated.
+- Expanded scratchpad folder workflows with create-in-folder actions, recursive folder deletion with confirmation, and cleanup of backing files when folders are removed.
+- Expanded GitHub Copilot scratchpad tools to 11 operations, including folder create/rename/move/delete, root moves, root-level and workspace-wide listing, and direct content reads/updates.
+- Increased scratchpad capacity to 400 files and expanded scratchpad folder depth handling to 10 levels for imports and moves.
+
+---
+
 # 1.2.0 - May 2026
 
 - Added hierarchical folder support for scratchpads (up to 5 levels deep).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/nazariitaran/vs-codebench/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/nazariitaran/vs-codebench/actions/workflows/ci.yml)
 [![Release](https://github.com/nazariitaran/vs-codebench/actions/workflows/release.yml/badge.svg)](https://github.com/nazariitaran/vs-codebench/actions/workflows/release.yml)
-[![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-v1.2.0-blue)](https://marketplace.visualstudio.com/items?itemName=nazariitaran.vs-codebench)
+[![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-v1.3.0-blue)](https://marketplace.visualstudio.com/items?itemName=nazariitaran.vs-codebench)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 <!-- [![Open VSX](https://img.shields.io/open-vsx/v/nazariitaran/vs-codebench)](https://open-vsx.org/extension/nazariitaran/vs-codebench)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/nazariitaran/vs-codebench)](https://open-vsx.org/extension/nazariitaran/vs-codebench) -->
@@ -37,11 +37,11 @@ Organise your bookmarks by folder or colour:
 ![VS CodeBench Overview](./docs/6_bookmark_organize.gif)
 
 ### Scratchpads
-Quick, persistent scratch files to capture ideas/snippets, organized into hierarchical folders.
+Quick, persistent scratch files to capture ideas and snippets, with hierarchical folders, directory import, and stable virtual scratchpad URIs that stay decoupled from backing files on disk.
 ![VS CodeBench Overview](./docs/7_scratchpads.gif)
 
 ### GitHub Copilot Tools
-Built-in tools for GitHub Copilot to read and manage CodeBench bookmarks and scratchpads directly in the current workspace.
+Built-in tools for GitHub Copilot to read and manage CodeBench bookmarks and scratchpads directly in the current workspace, including 11 scratchpad operations for content, folders, and moves.
 
 
 ## Default Keyboard Shortcuts
@@ -58,6 +58,9 @@ You can change these in File > Preferences > Keyboard Shortcuts.
 - CodeBench: Toggle Bookmark
 - CodeBench: Change Bookmark Color
 - CodeBench: Create Scratchpad
+- CodeBench: Create Scratchpad Here
+- CodeBench: New Scratchpad Folder
+- CodeBench: Import Scratchpads
 - CodeBench: Save Unsaved File as Scratchpad
 
 ## Views
@@ -78,13 +81,20 @@ You can change these in File > Preferences > Keyboard Shortcuts.
 - Scratchpads
   - File name length: 1–75 characters
   - Folder name length: 1–75 characters
-  - Folder depth: up to 5 levels deep (moving/creating beyond this is blocked)
-  - Count: up to 200 scratchpad files (hard limit); attempts beyond this are blocked
+  - Folder depth: up to 10 levels deep for moves and imports
+  - Count: up to 400 scratchpad files (hard limit); attempts beyond this are blocked
 
 ## Requirements
 - VS Code 1.101.0 or newer
 
 ## Release Notes
+
+### 1.3.0
+- Added a scratchpad import workflow that can ingest a folder tree, preserve structure, skip binary files and symlinks, overwrite matching scratchpads in place, and generate an import summary scratchpad.
+- Refactored scratchpads onto a dedicated `codebench-scratchpad` file system so logical names and folder paths stay stable even when backing files are renamed or migrated.
+- Expanded scratchpad folder workflows with create-in-folder actions, recursive folder deletion with confirmation, and cleanup of backing files when folders are removed.
+- Expanded GitHub Copilot scratchpad tools to 11 operations, including folder create/rename/move/delete, root moves, root-level and workspace-wide listing, and direct content reads/updates.
+- Increased scratchpad capacity to 400 files and expanded scratchpad folder depth handling to 10 levels for imports and moves.
 
 ### 1.2.0
 - Added hierarchical folder support for scratchpads (up to 5 levels deep).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vs-codebench",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vs-codebench",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "uuid": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vs-codebench",
   "displayName": "VS CodeBench",
   "description": "A productivity extension that helps you organize your tasks, code notes, and bookmarks efficiently.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "nazariitaran",
   "icon": "icon.png",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "license": "MIT",
   "pricing": "Free",
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onFileSystem:codebench-scratchpad"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -161,6 +162,12 @@
       {
         "command": "vs-codebench.createScratchpad",
         "title": "Create Scratchpad",
+        "icon": "$(new-file)",
+        "category": "CodeBench"
+      },
+      {
+        "command": "vs-codebench.createScratchpadInFolder",
+        "title": "Create Scratchpad Here",
         "icon": "$(new-file)",
         "category": "CodeBench"
       },
@@ -417,7 +424,7 @@
         "name": "codebench_get_scratchpads",
         "displayName": "Get Scratchpads",
         "userDescription": "Read scratchpads from VS CodeBench.",
-        "modelDescription": "List scratchpad metadata for the current workspace, optionally filtered by language or name substring. This tool does not return scratchpad content.",
+        "modelDescription": "List scratchpad metadata for the current workspace. By default this returns root-level scratchpads only, plus all folder metadata. Use folderId to inspect one folder or includeAll=true to list scratchpads across all folders. This tool does not return scratchpad content.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "codebench-scratchpads",
         "inputSchema": {
@@ -434,6 +441,10 @@
             "folderId": {
               "type": "string",
               "description": "Optional folder ID to filter scratchpads by parent folder."
+            },
+            "includeAll": {
+              "type": "boolean",
+              "description": "When true and folderId is omitted, return scratchpads from all folders instead of root-level only."
             }
           },
           "additionalProperties": false
@@ -462,7 +473,7 @@
         "name": "codebench_create_scratchpad",
         "displayName": "Create Scratchpad",
         "userDescription": "Create a scratchpad in VS CodeBench.",
-        "modelDescription": "Create a scratchpad with optional name, language, and content. If name is omitted, a default scratchpad_<n>.<ext> name is generated.",
+        "modelDescription": "Create a scratchpad with optional name, language, content, and parentFolderId. If name is omitted, a default scratchpad_<n>.<ext> name is generated. Use get_scratchpads first when you need a target folder ID.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "codebench-create-scratchpad",
         "inputSchema": {
@@ -577,15 +588,38 @@
         }
       },
       {
+        "name": "codebench_rename_scratchpad_folder",
+        "displayName": "Rename Scratchpad Folder",
+        "userDescription": "Rename a scratchpad folder in VS CodeBench.",
+        "modelDescription": "Rename an existing scratchpad folder by folderId. Use get_scratchpads first to discover valid folder IDs.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "codebench-rename-scratchpad-folder",
+        "inputSchema": {
+          "type": "object",
+          "required": ["folderId", "newName"],
+          "properties": {
+            "folderId": {
+              "type": "string",
+              "description": "ID of the scratchpad folder to rename."
+            },
+            "newName": {
+              "type": "string",
+              "description": "New folder name."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
         "name": "codebench_move_scratchpad_to_folder",
         "displayName": "Move Scratchpad To Folder",
         "userDescription": "Move an existing scratchpad into a scratchpad folder.",
-        "modelDescription": "Place an existing VS CodeBench scratchpad into a specific folder. Use get_scratchpads first to resolve scratchpadId and folderId.",
+        "modelDescription": "Place an existing VS CodeBench scratchpad into a specific folder. Use get_scratchpads first to resolve scratchpadId and folderId. Omit folderId to move the scratchpad back to the root.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "codebench-move-scratchpad-folder",
         "inputSchema": {
           "type": "object",
-          "required": ["scratchpadId", "folderId"],
+          "required": ["scratchpadId"],
           "properties": {
             "scratchpadId": {
               "type": "string",
@@ -593,7 +627,30 @@
             },
             "folderId": {
               "type": "string",
-              "description": "Target scratchpad folder ID."
+              "description": "Optional target scratchpad folder ID. Omit to move the scratchpad to the root."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "name": "codebench_move_scratchpad_folder",
+        "displayName": "Move Scratchpad Folder",
+        "userDescription": "Move a scratchpad folder in VS CodeBench.",
+        "modelDescription": "Move an existing scratchpad folder under another scratchpad folder. Use get_scratchpads first to resolve folder IDs. Omit targetFolderId to move the folder to the root.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "codebench-move-scratchpad-folder-node",
+        "inputSchema": {
+          "type": "object",
+          "required": ["folderId"],
+          "properties": {
+            "folderId": {
+              "type": "string",
+              "description": "Existing scratchpad folder ID to move."
+            },
+            "targetFolderId": {
+              "type": "string",
+              "description": "Optional destination folder ID. Omit to move the folder to the root."
             }
           },
           "additionalProperties": false
@@ -603,7 +660,7 @@
         "name": "codebench_delete_scratchpad_folder",
         "displayName": "Delete Scratchpad Folder",
         "userDescription": "Delete a scratchpad folder and its contents.",
-        "modelDescription": "Delete a scratchpad folder by folderId. Recursively removes all nested subfolders and moves contained scratchpads to root.",
+        "modelDescription": "Delete a scratchpad folder by folderId. Recursively removes the folder, all nested subfolders, and all contained scratchpads.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "codebench-delete-scratchpad-folder",
         "inputSchema": {
@@ -696,12 +753,12 @@
           "group": "navigation@6"
         },
         {
-          "command": "vs-codebench.createScratchpad",
+          "command": "vs-codebench.addRootScratchpadFolder",
           "when": "view == scratchpadsView",
           "group": "navigation"
         },
         {
-          "command": "vs-codebench.addRootScratchpadFolder",
+          "command": "vs-codebench.createScratchpad",
           "when": "view == scratchpadsView",
           "group": "navigation@2"
         }
@@ -731,6 +788,11 @@
           "command": "vs-codebench.moveTodoDown",
           "when": "view == todosView && (viewItem == todoItem || viewItem == todoItemMaxDepth)",
           "group": "navigation@2"
+        },
+        {
+          "command": "vs-codebench.createScratchpadInFolder",
+          "when": "view == scratchpadsView && (viewItem == scratchpadFolder || viewItem == scratchpadFolderMaxDepth)",
+          "group": "inline@1"
         },
         {
           "command": "vs-codebench.addFolder",
@@ -773,14 +835,19 @@
           "group": "inline@2"
         },
         {
+          "command": "vs-codebench.createScratchpadInFolder",
+          "when": "view == scratchpadsView && (viewItem == scratchpadFolder || viewItem == scratchpadFolderMaxDepth)",
+          "group": "inline@0"
+        },
+        {
           "command": "vs-codebench.addScratchpadFolder",
           "when": "view == scratchpadsView && viewItem == scratchpadFolder",
-          "group": "inline@0"
+          "group": "inline@1"
         },
         {
           "command": "vs-codebench.editScratchpadFolder",
           "when": "view == scratchpadsView && (viewItem == scratchpadFolder || viewItem == scratchpadFolderMaxDepth)",
-          "group": "inline@1"
+          "group": "inline@2"
         },
         {
           "command": "vs-codebench.deleteScratchpadFolder",

--- a/package.json
+++ b/package.json
@@ -216,6 +216,11 @@
         "title": "Delete Scratchpad Folder",
         "icon": "$(trash)",
         "category": "CodeBench"
+      },
+      {
+        "command": "vs-codebench.importScratchpads",
+        "title": "Import Scratchpads from Directory",
+        "category": "CodeBench"
       }
     ],
     "languageModelTools": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 
 import { TodosProvider, registerTodoCommands } from './features/todos';
 import { BookmarksProvider, registerBookmarkAiTools, registerBookmarkCommands } from './features/bookmarks';
-import { ScratchpadsProvider, registerScratchpadAiTools, registerScratchpadCommands } from './features/scratchpads';
+import { ScratchpadFileSystemProvider, ScratchpadsProvider, registerScratchpadAiTools, registerScratchpadCommands } from './features/scratchpads';
+import { SCRATCHPAD_URI_SCHEME } from './features/scratchpads/ScratchpadService';
 
 import { TodoDragAndDropController } from './features/todos/views/TodoDragAndDropController';
 import { BookmarkDragAndDropController } from './features/bookmarks/views/BookmarkDragAndDropController';
@@ -12,6 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
   const todosProvider = new TodosProvider(context);
   const bookmarksProvider = new BookmarksProvider(context);
   const scratchpadsProvider = new ScratchpadsProvider(context);
+  const scratchpadFileSystemProvider = new ScratchpadFileSystemProvider(scratchpadsProvider);
 
   const todosTreeView = vscode.window.createTreeView('todosView', {
     treeDataProvider: todosProvider,
@@ -36,7 +38,15 @@ export function activate(context: vscode.ExtensionContext) {
     dragAndDropController: new ScratchpadDragAndDropController(scratchpadsProvider)
   });
 
-  context.subscriptions.push(todosTreeView, bookmarksTreeView, scratchpadsTreeView);
+  context.subscriptions.push(
+    todosTreeView,
+    bookmarksTreeView,
+    scratchpadsTreeView,
+    vscode.workspace.registerFileSystemProvider(SCRATCHPAD_URI_SCHEME, scratchpadFileSystemProvider, {
+      isCaseSensitive: true,
+      isReadonly: false
+    })
+  );
 
   context.subscriptions.push({
     dispose: () => {

--- a/src/features/scratchpads/Models.ts
+++ b/src/features/scratchpads/Models.ts
@@ -1,3 +1,5 @@
+export const MAX_SCRATCH_FILES = 400;
+
 export interface ScratchFile {
     id: string;
     name: string;

--- a/src/features/scratchpads/Models.ts
+++ b/src/features/scratchpads/Models.ts
@@ -3,7 +3,7 @@ export const MAX_SCRATCH_FILES = 400;
 export interface ScratchFile {
     id: string;
     name: string;
-    content: string;
+    backingFileName?: string;
     language?: string;
     createdAt: number;
     lastModified: number;
@@ -27,4 +27,4 @@ export interface ScratchpadData {
     folders?: ScratchpadFolder[];
 }
 
-export const CURRENT_SCRATCHPAD_VERSION = 2;
+export const CURRENT_SCRATCHPAD_VERSION = 3;

--- a/src/features/scratchpads/ScratchpadAiTools.ts
+++ b/src/features/scratchpads/ScratchpadAiTools.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ScratchpadsProvider } from './ScratchpadsProvider';
+import ScratchpadValidator from './ScratchpadValidator';
 
 interface GetScratchpadsInput {
   language?: string;
@@ -230,6 +231,13 @@ class CreateScratchpadFolderTool implements vscode.LanguageModelTool<CreateScrat
     options: vscode.LanguageModelToolInvocationOptions<CreateScratchpadFolderInput>
   ): Promise<vscode.LanguageModelToolResult> {
     const input = options.input;
+
+    // Validate folder name before creation
+    const validationError = ScratchpadValidator.validateFolderName(input.name);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
     const folder = await this.scratchpadsProvider.addFolder(input.name, input.parentFolderId);
 
     return resultFromObject({

--- a/src/features/scratchpads/ScratchpadAiTools.ts
+++ b/src/features/scratchpads/ScratchpadAiTools.ts
@@ -286,7 +286,7 @@ class DeleteScratchpadFolderTool implements vscode.LanguageModelTool<DeleteScrat
       throw new Error('Folder not found. Provide a valid folderId.');
     }
 
-    await this.scratchpadsProvider.deleteFolder(input.folderId);
+    await this.scratchpadsProvider.deleteFolderForTools(input.folderId);
 
     return resultFromObject({
       success: true,

--- a/src/features/scratchpads/ScratchpadAiTools.ts
+++ b/src/features/scratchpads/ScratchpadAiTools.ts
@@ -6,6 +6,7 @@ interface GetScratchpadsInput {
   language?: string;
   nameContains?: string;
   folderId?: string;
+  includeAll?: boolean;
 }
 
 interface GetScratchpadContentInput {
@@ -38,9 +39,19 @@ interface CreateScratchpadFolderInput {
   parentFolderId?: string;
 }
 
+interface RenameScratchpadFolderInput {
+  folderId: string;
+  newName: string;
+}
+
 interface MoveScratchpadToFolderInput {
   scratchpadId: string;
+  folderId?: string;
+}
+
+interface MoveScratchpadFolderInput {
   folderId: string;
+  targetFolderId?: string;
 }
 
 interface DeleteScratchpadFolderInput {
@@ -91,6 +102,18 @@ function toFolderMetadata(folder: {
   };
 }
 
+function getScratchpadFolderOrThrow(
+  scratchpadsProvider: ScratchpadsProvider,
+  folderId: string,
+  missingMessage = 'Folder not found. Provide a valid folderId.'
+) {
+  const folder = scratchpadsProvider.scratchpadService.getFolderById(folderId);
+  if (!folder) {
+    throw new Error(missingMessage);
+  }
+  return folder;
+}
+
 class GetScratchpadsTool implements vscode.LanguageModelTool<GetScratchpadsInput> {
   constructor(private scratchpadsProvider: ScratchpadsProvider) {}
 
@@ -99,11 +122,13 @@ class GetScratchpadsTool implements vscode.LanguageModelTool<GetScratchpadsInput
   ): Promise<vscode.LanguageModelToolResult> {
     const input = options.input ?? {};
     let scratchpads = this.scratchpadsProvider.getAllScratchpads();
+    const includeAll = input.includeAll ?? false;
 
     if (input.folderId !== undefined) {
+      getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
       scratchpads = scratchpads.filter(file => file.parentId === input.folderId);
-    } else {
-      // Default: show root-level only (backwards compatible)
+    } else if (!includeAll) {
+      // Default: show root-level only unless the caller explicitly asks for all scratchpads.
       scratchpads = scratchpads.filter(file => !file.parentId);
     }
 
@@ -120,6 +145,7 @@ class GetScratchpadsTool implements vscode.LanguageModelTool<GetScratchpadsInput
     const folders = this.scratchpadsProvider.scratchpadService.getFolders();
 
     return resultFromObject({
+      scope: input.folderId !== undefined ? 'folder' : includeAll ? 'all' : 'root',
       count: scratchpads.length,
       scratchpads: scratchpads.map(toScratchpadMetadata),
       folders: folders.map(toFolderMetadata)
@@ -156,7 +182,21 @@ class CreateScratchpadTool implements vscode.LanguageModelTool<CreateScratchpadI
   async invoke(
     options: vscode.LanguageModelToolInvocationOptions<CreateScratchpadInput>
   ): Promise<vscode.LanguageModelToolResult> {
-    await this.scratchpadsProvider.createScratchpadForTools(options.input ?? {});
+    const input = options.input ?? {};
+    const validationError = ScratchpadValidator.validateForCreate(input);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    if (input.parentFolderId) {
+      getScratchpadFolderOrThrow(
+        this.scratchpadsProvider,
+        input.parentFolderId,
+        'Parent folder not found. Provide a valid parentFolderId.'
+      );
+    }
+
+    await this.scratchpadsProvider.createScratchpadForTools(input);
 
     const scratchpads = this.scratchpadsProvider.getAllScratchpads().map(toScratchpadMetadata);
     return resultFromObject({
@@ -238,11 +278,48 @@ class CreateScratchpadFolderTool implements vscode.LanguageModelTool<CreateScrat
       throw new Error(validationError);
     }
 
+    if (input.parentFolderId) {
+      const parentFolder = getScratchpadFolderOrThrow(
+        this.scratchpadsProvider,
+        input.parentFolderId,
+        'Parent folder not found. Provide a valid parentFolderId.'
+      );
+      const parentDepth = this.scratchpadsProvider.scratchpadService.getFolderDepth(parentFolder.id);
+      if (parentDepth >= 5) {
+        throw new Error('Maximum folder depth (5 levels) reached.');
+      }
+    }
+
     const folder = await this.scratchpadsProvider.addFolder(input.name, input.parentFolderId);
 
     return resultFromObject({
       success: true,
       folder: toFolderMetadata(folder)
+    });
+  }
+}
+
+class RenameScratchpadFolderTool implements vscode.LanguageModelTool<RenameScratchpadFolderInput> {
+  constructor(private scratchpadsProvider: ScratchpadsProvider) {}
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<RenameScratchpadFolderInput>
+  ): Promise<vscode.LanguageModelToolResult> {
+    const input = options.input;
+    const folder = getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
+
+    const validationError = ScratchpadValidator.validateFolderName(input.newName);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    await this.scratchpadsProvider.editFolder(input.folderId, input.newName);
+    const updated = getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
+
+    return resultFromObject({
+      success: true,
+      folder: toFolderMetadata(updated),
+      previousName: folder.name
     });
   }
 }
@@ -259,9 +336,8 @@ class MoveScratchpadToFolderTool implements vscode.LanguageModelTool<MoveScratch
       throw new Error('Scratchpad not found. Provide a valid scratchpadId.');
     }
 
-    const folder = this.scratchpadsProvider.scratchpadService.getFolderById(input.folderId);
-    if (!folder) {
-      throw new Error('Folder not found. Provide a valid folderId.');
+    if (input.folderId) {
+      getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
     }
 
     await this.scratchpadsProvider.moveToFolder(input.scratchpadId, input.folderId);
@@ -269,7 +345,36 @@ class MoveScratchpadToFolderTool implements vscode.LanguageModelTool<MoveScratch
 
     return resultFromObject({
       success: true,
+      movedToRoot: !input.folderId,
       scratchpad: updated ? toScratchpadMetadata(updated) : undefined
+    });
+  }
+}
+
+class MoveScratchpadFolderTool implements vscode.LanguageModelTool<MoveScratchpadFolderInput> {
+  constructor(private scratchpadsProvider: ScratchpadsProvider) {}
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<MoveScratchpadFolderInput>
+  ): Promise<vscode.LanguageModelToolResult> {
+    const input = options.input;
+    getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
+
+    if (input.targetFolderId) {
+      getScratchpadFolderOrThrow(
+        this.scratchpadsProvider,
+        input.targetFolderId,
+        'Target folder not found. Provide a valid targetFolderId.'
+      );
+    }
+
+    await this.scratchpadsProvider.moveToFolder(input.folderId, input.targetFolderId);
+    const updated = getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
+
+    return resultFromObject({
+      success: true,
+      movedToRoot: !input.targetFolderId,
+      folder: toFolderMetadata(updated)
     });
   }
 }
@@ -281,10 +386,7 @@ class DeleteScratchpadFolderTool implements vscode.LanguageModelTool<DeleteScrat
     options: vscode.LanguageModelToolInvocationOptions<DeleteScratchpadFolderInput>
   ): Promise<vscode.LanguageModelToolResult> {
     const input = options.input;
-    const folder = this.scratchpadsProvider.scratchpadService.getFolderById(input.folderId);
-    if (!folder) {
-      throw new Error('Folder not found. Provide a valid folderId.');
-    }
+    getScratchpadFolderOrThrow(this.scratchpadsProvider, input.folderId);
 
     await this.scratchpadsProvider.deleteFolderForTools(input.folderId);
 
@@ -307,7 +409,9 @@ export function registerScratchpadAiTools(
     vscode.lm.registerTool('codebench_rename_scratchpad', new RenameScratchpadTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_delete_scratchpad', new DeleteScratchpadTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_create_scratchpad_folder', new CreateScratchpadFolderTool(scratchpadsProvider)),
+    vscode.lm.registerTool('codebench_rename_scratchpad_folder', new RenameScratchpadFolderTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_move_scratchpad_to_folder', new MoveScratchpadToFolderTool(scratchpadsProvider)),
+    vscode.lm.registerTool('codebench_move_scratchpad_folder', new MoveScratchpadFolderTool(scratchpadsProvider)),
     vscode.lm.registerTool('codebench_delete_scratchpad_folder', new DeleteScratchpadFolderTool(scratchpadsProvider))
   );
 }

--- a/src/features/scratchpads/ScratchpadCommands.ts
+++ b/src/features/scratchpads/ScratchpadCommands.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 import { ScratchpadsProvider } from './ScratchpadsProvider';
 import ScratchpadValidator from './ScratchpadValidator';
+import { ScratchFile } from './Models';
 
 export function registerScratchpadCommands(
   context: vscode.ExtensionContext,
@@ -78,6 +81,77 @@ export function registerScratchpadCommands(
     vscode.commands.registerCommand('vs-codebench.deleteScratchpadFolder', async (item: any) => {
       if (item && item.id) {
         await scratchpadsProvider.deleteFolder(item.id);
+      }
+    }),
+
+    vscode.commands.registerCommand('vs-codebench.importScratchpads', async () => {
+      const selected = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectMany: false,
+        openLabel: 'Select folder to import scratchpads from'
+      });
+
+      if (!selected || selected.length === 0) {
+        return;
+      }
+
+      const dirPath = selected[0].fsPath;
+
+      const importChoice = await vscode.window.showQuickPick(
+        [
+          { label: 'Yes', description: "Import into a dedicated '_import' folder" },
+          { label: 'No', description: 'Import to root' }
+        ],
+        {
+          placeHolder: "Import into a dedicated folder?",
+          title: 'Import Scratchpads'
+        }
+      );
+
+      if (!importChoice) {
+        return;
+      }
+
+      let parentFolderId: string | undefined;
+      let folderName: string | undefined;
+      if (importChoice.label === 'Yes') {
+        folderName = scratchpadsProvider.scratchpadService.findNextImportFolderName();
+        const folder = await scratchpadsProvider.addFolder(folderName, undefined);
+        parentFolderId = folder.id;
+      }
+
+      const result = await scratchpadsProvider.importScratchpadsFromDirectory(dirPath, parentFolderId);
+
+      // Build summary
+      const parts: string[] = [];
+      if (result.imported > 0) { parts.push(`${result.imported} imported`); }
+      if (result.overwritten > 0) { parts.push(`${result.overwritten} overwritten`); }
+      if (result.skipped > 0) { parts.push(`${result.skipped} skipped (non-text or limit reached)`); }
+      if (result.errors > 0) { parts.push(`${result.errors} errors`); }
+
+      const message = parts.length > 0
+        ? `Import complete: ${parts.join(', ')}`
+        : 'Import complete: nothing to import';
+
+      vscode.window.showInformationMessage(message);
+
+      // Create import summary scratchpad
+      if (result.imported > 0 || result.overwritten > 0 || result.skipped > 0) {
+        const { summaryContent, importedFilePaths } = scratchpadsProvider.scratchpadService.buildImportSummary(
+          result,
+          dirPath,
+          folderName,
+          parentFolderId
+        );
+
+        // Use unique name to avoid conflict if summary already exists
+        const summaryName = 'import_summary_' + Date.now() + '.md';
+        const summaryScratchpad = await scratchpadsProvider.scratchpadService.createScratchFile(summaryName, 'markdown', parentFolderId);
+        await scratchpadsProvider.scratchpadService.updateFileContent(summaryScratchpad.id, summaryContent);
+
+        // Open the summary scratchpad
+        const doc = await vscode.workspace.openTextDocument(scratchpadsProvider.scratchpadService.getFilePath(summaryScratchpad.id));
+        await vscode.window.showTextDocument(doc);
       }
     })
   );

--- a/src/features/scratchpads/ScratchpadCommands.ts
+++ b/src/features/scratchpads/ScratchpadCommands.ts
@@ -150,8 +150,7 @@ export function registerScratchpadCommands(
         await scratchpadsProvider.scratchpadService.updateFileContent(summaryScratchpad.id, summaryContent);
 
         // Open the summary scratchpad
-        const doc = await vscode.workspace.openTextDocument(scratchpadsProvider.scratchpadService.getFilePath(summaryScratchpad.id));
-        await vscode.window.showTextDocument(doc);
+        await scratchpadsProvider.openScratchFile(summaryScratchpad.id);
       }
     })
   );

--- a/src/features/scratchpads/ScratchpadCommands.ts
+++ b/src/features/scratchpads/ScratchpadCommands.ts
@@ -14,6 +14,10 @@ export function registerScratchpadCommands(
       await scratchpadsProvider.createScratchFile();
     }),
 
+    vscode.commands.registerCommand('vs-codebench.createScratchpadInFolder', async (item?: any) => {
+      await scratchpadsProvider.createScratchFile(item?.id);
+    }),
+
     vscode.commands.registerCommand('vs-codebench.saveUnsavedAsScratchpad', async () => {
       await scratchpadsProvider.saveActiveUnsavedEditorAsScratchpad();
     }),

--- a/src/features/scratchpads/ScratchpadFileSystemProvider.ts
+++ b/src/features/scratchpads/ScratchpadFileSystemProvider.ts
@@ -1,0 +1,106 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ScratchpadsProvider } from './ScratchpadsProvider';
+
+export class ScratchpadFileSystemProvider implements vscode.FileSystemProvider {
+  private readonly _onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+  readonly onDidChangeFile = this._onDidChangeFile.event;
+
+  private readonly encoder = new TextEncoder();
+  private readonly decoder = new TextDecoder();
+
+  constructor(private readonly scratchpadsProvider: ScratchpadsProvider) {}
+
+  watch(): vscode.Disposable {
+    return new vscode.Disposable(() => {});
+  }
+
+  stat(uri: vscode.Uri): vscode.FileStat {
+    const file = this.getScratchFileForUri(uri);
+    const content = this.scratchpadsProvider.scratchpadService.loadFileContent(file.id);
+
+    return {
+      type: vscode.FileType.File,
+      ctime: file.createdAt,
+      mtime: file.lastModified,
+      size: Buffer.byteLength(content, 'utf8')
+    };
+  }
+
+  readDirectory(): [string, vscode.FileType][] {
+    return [];
+  }
+
+  createDirectory(): void {
+    throw vscode.FileSystemError.NoPermissions('Scratchpad directories are managed by VS CodeBench.');
+  }
+
+  readFile(uri: vscode.Uri): Uint8Array {
+    const file = this.getScratchFileForUri(uri);
+    const content = this.scratchpadsProvider.scratchpadService.loadFileContent(file.id);
+    return this.encoder.encode(content);
+  }
+
+  async writeFile(
+    uri: vscode.Uri,
+    content: Uint8Array,
+    options: { readonly create: boolean; readonly overwrite: boolean; }
+  ): Promise<void> {
+    const id = this.getScratchpadId(uri);
+    const existing = this.scratchpadsProvider.scratchpadService.getScratchFile(id);
+
+    if (!existing && !options.create) {
+      throw vscode.FileSystemError.FileNotFound(uri);
+    }
+
+    if (!existing) {
+      throw vscode.FileSystemError.NoPermissions('Scratchpads must be created through VS CodeBench commands.');
+    }
+
+    await this.scratchpadsProvider.scratchpadService.updateFileContent(id, this.decoder.decode(content));
+    this.scratchpadsProvider.refresh();
+    this._onDidChangeFile.fire([{ type: vscode.FileChangeType.Changed, uri }]);
+  }
+
+  async delete(uri: vscode.Uri): Promise<void> {
+    const id = this.getScratchpadId(uri);
+    await this.scratchpadsProvider.deleteScratchFileForTools(id);
+    this.scratchpadsProvider.refresh();
+    this._onDidChangeFile.fire([{ type: vscode.FileChangeType.Deleted, uri }]);
+  }
+
+  async rename(
+    oldUri: vscode.Uri,
+    newUri: vscode.Uri,
+    _options: { readonly overwrite: boolean; }
+  ): Promise<void> {
+    const id = this.getScratchpadId(oldUri);
+    const targetName = path.posix.basename(newUri.path);
+
+    await this.scratchpadsProvider.scratchpadService.renameScratchFile(id, targetName);
+
+    const updatedUri = this.scratchpadsProvider.scratchpadService.getScratchpadUri(id);
+    this.scratchpadsProvider.refresh();
+    this._onDidChangeFile.fire([
+      { type: vscode.FileChangeType.Deleted, uri: oldUri },
+      { type: vscode.FileChangeType.Created, uri: updatedUri }
+    ]);
+  }
+
+  private getScratchpadId(uri: vscode.Uri): string {
+    const id = this.scratchpadsProvider.scratchpadService.getScratchpadIdFromUri(uri);
+    if (!id) {
+      throw vscode.FileSystemError.FileNotFound(uri);
+    }
+    return id;
+  }
+
+  private getScratchFileForUri(uri: vscode.Uri) {
+    const id = this.getScratchpadId(uri);
+    const file = this.scratchpadsProvider.scratchpadService.getScratchFile(id);
+    if (!file) {
+      throw vscode.FileSystemError.FileNotFound(uri);
+    }
+    return file;
+  }
+}

--- a/src/features/scratchpads/ScratchpadFileSystemProvider.ts
+++ b/src/features/scratchpads/ScratchpadFileSystemProvider.ts
@@ -15,7 +15,8 @@ export class ScratchpadFileSystemProvider implements vscode.FileSystemProvider {
     return new vscode.Disposable(() => {});
   }
 
-  stat(uri: vscode.Uri): vscode.FileStat {
+  async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
+    await this.scratchpadsProvider.whenReady();
     const file = this.getScratchFileForUri(uri);
     const content = this.scratchpadsProvider.scratchpadService.loadFileContent(file.id);
 
@@ -35,7 +36,8 @@ export class ScratchpadFileSystemProvider implements vscode.FileSystemProvider {
     throw vscode.FileSystemError.NoPermissions('Scratchpad directories are managed by VS CodeBench.');
   }
 
-  readFile(uri: vscode.Uri): Uint8Array {
+  async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+    await this.scratchpadsProvider.whenReady();
     const file = this.getScratchFileForUri(uri);
     const content = this.scratchpadsProvider.scratchpadService.loadFileContent(file.id);
     return this.encoder.encode(content);
@@ -46,6 +48,7 @@ export class ScratchpadFileSystemProvider implements vscode.FileSystemProvider {
     content: Uint8Array,
     options: { readonly create: boolean; readonly overwrite: boolean; }
   ): Promise<void> {
+    await this.scratchpadsProvider.whenReady();
     const id = this.getScratchpadId(uri);
     const existing = this.scratchpadsProvider.scratchpadService.getScratchFile(id);
 
@@ -63,6 +66,7 @@ export class ScratchpadFileSystemProvider implements vscode.FileSystemProvider {
   }
 
   async delete(uri: vscode.Uri): Promise<void> {
+    await this.scratchpadsProvider.whenReady();
     const id = this.getScratchpadId(uri);
     await this.scratchpadsProvider.deleteScratchFileForTools(id);
     this.scratchpadsProvider.refresh();
@@ -74,6 +78,7 @@ export class ScratchpadFileSystemProvider implements vscode.FileSystemProvider {
     newUri: vscode.Uri,
     _options: { readonly overwrite: boolean; }
   ): Promise<void> {
+    await this.scratchpadsProvider.whenReady();
     const id = this.getScratchpadId(oldUri);
     const targetName = path.posix.basename(newUri.path);
 

--- a/src/features/scratchpads/ScratchpadService.ts
+++ b/src/features/scratchpads/ScratchpadService.ts
@@ -136,7 +136,7 @@ export class ScratchpadService {
     }
 
     const parentId = folder.parentId;
-    this.deleteFolderRecursive(id);
+    await this.deleteFolderRecursive(id);
 
     // Normalize order after deletion
     const siblings = this.getFolderSiblings(parentId);
@@ -146,18 +146,32 @@ export class ScratchpadService {
     await this.saveMetadata();
   }
 
-  private deleteFolderRecursive(folderId: string): void {
-    // Move all files in this folder to root (parentId = undefined)
-    this.scratchFiles.forEach(file => {
+  private async deleteFolderRecursive(folderId: string): Promise<void> {
+    // Delete all files in this folder and remove their backing files from storage.
+    for (const [fileId, file] of this.scratchFiles.entries()) {
       if (file.parentId === folderId) {
-        file.parentId = undefined;
+        const filePath = this.getFilePath(fileId);
+
+        try {
+          const exists = await fs.promises
+            .access(filePath, fs.constants.F_OK)
+            .then(() => true)
+            .catch(() => false);
+          if (exists) {
+            await fs.promises.unlink(filePath);
+          }
+        } catch (error) {
+          console.error('Failed to delete file:', error);
+        }
+
+        this.scratchFiles.delete(fileId);
       }
-    });
+    }
 
     // Recursively delete subfolders
     const subfolders = this.folders.filter(f => f.parentId === folderId);
     for (const subfolder of subfolders) {
-      this.deleteFolderRecursive(subfolder.id);
+      await this.deleteFolderRecursive(subfolder.id);
     }
 
     // Delete the folder itself

--- a/src/features/scratchpads/ScratchpadService.ts
+++ b/src/features/scratchpads/ScratchpadService.ts
@@ -5,6 +5,18 @@ import * as fs from 'fs';
 import { ScratchFile, ScratchpadFolder, ScratchpadData, CURRENT_SCRATCHPAD_VERSION, MAX_SCRATCH_FILES } from './Models';
 import { NamespacedStorageService, createNamespacedStorage } from '../../common/storage/StorageService';
 
+export const SCRATCHPAD_URI_SCHEME = 'codebench-scratchpad';
+
+interface LegacyScratchFile extends ScratchFile {
+  content?: string;
+}
+
+interface LegacyScratchpadData {
+  version: number;
+  files: LegacyScratchFile[];
+  folders?: ScratchpadFolder[];
+}
+
 export class ScratchpadService {
   private scratchFiles: Map<string, ScratchFile> = new Map();
   private folders: ScratchpadFolder[] = [];
@@ -35,26 +47,25 @@ export class ScratchpadService {
 
   async loadScratchFiles(): Promise<void> {
     try {
-      const data = await this.storage.retrieve<ScratchpadData>('metadata', {
+      const data = await this.storage.retrieve<LegacyScratchpadData>('metadata', {
         version: CURRENT_SCRATCHPAD_VERSION,
         files: [],
         folders: []
       }, { scope: 'auto' });
 
-      this.scratchFiles.clear();
-      this.folders = [];
+      const migrated = await this.migrateScratchpadData(data);
 
-      // v1→v2 migration: initialize parentId on existing files
-      if (data.version < 2) {
-        data.files.forEach(file => {
-          const migrated: ScratchFile = { ...file, parentId: undefined };
-          this.scratchFiles.set(file.id, migrated);
-        });
-      } else {
-        data.files.forEach(file => {
-          this.scratchFiles.set(file.id, file);
-        });
-        this.folders = data.folders || [];
+      await this.ensureBackingFilesExist(migrated.files, migrated.legacyContentById);
+
+      this.scratchFiles.clear();
+      this.folders = migrated.folders;
+
+      migrated.files.forEach(file => {
+        this.scratchFiles.set(file.id, file);
+      });
+
+      if (migrated.changed) {
+        await this.saveMetadata();
       }
     } catch (error) {
       console.error('Failed to load scratch files:', error);
@@ -150,20 +161,7 @@ export class ScratchpadService {
     // Delete all files in this folder and remove their backing files from storage.
     for (const [fileId, file] of this.scratchFiles.entries()) {
       if (file.parentId === folderId) {
-        const filePath = this.getFilePath(fileId);
-
-        try {
-          const exists = await fs.promises
-            .access(filePath, fs.constants.F_OK)
-            .then(() => true)
-            .catch(() => false);
-          if (exists) {
-            await fs.promises.unlink(filePath);
-          }
-        } catch (error) {
-          console.error('Failed to delete file:', error);
-        }
-
+        await this.deleteStoredFile(fileId);
         this.scratchFiles.delete(fileId);
       }
     }
@@ -396,18 +394,7 @@ export class ScratchpadService {
 
   async clearAll(): Promise<void> {
     for (const file of this.scratchFiles.values()) {
-      const filePath = this.getFilePath(file.id);
-      try {
-        const exists = await fs.promises
-          .access(filePath, fs.constants.F_OK)
-          .then(() => true)
-          .catch(() => false);
-        if (exists) {
-          await fs.promises.unlink(filePath);
-        }
-      } catch (error) {
-        console.error(`Failed to delete file ${filePath}:`, error);
-      }
+      await this.deleteStoredFile(file.id);
     }
 
     this.scratchFiles.clear();
@@ -432,10 +419,34 @@ export class ScratchpadService {
     return this.scratchFiles.get(id);
   }
 
+  getScratchpadIdFromUri(uri: vscode.Uri): string | undefined {
+    if (uri.scheme !== SCRATCHPAD_URI_SCHEME) {
+      return undefined;
+    }
+
+    const params = new URLSearchParams(uri.query);
+    return params.get('id') ?? undefined;
+  }
+
+  getScratchpadUri(id: string): vscode.Uri {
+    const file = this.scratchFiles.get(id);
+    if (!file) {
+      throw new Error(`Scratchpad not found for id ${id}`);
+    }
+    const virtualPath = `/${[...this.getFolderPathSegments(file.parentId), file.name].join('/')}`;
+    const params = new URLSearchParams({ id });
+
+    return vscode.Uri.from({
+      scheme: SCRATCHPAD_URI_SCHEME,
+      path: virtualPath,
+      query: params.toString()
+    });
+  }
+
   getFilePath(id: string): string {
     const file = this.scratchFiles.get(id);
     if (file) {
-      return path.join(this.scratchpadDirectory, file.name);
+      return this.getStoredFilePath(file);
     }
     // Fallback for files not yet in memory
     return path.join(this.scratchpadDirectory, `${id}.txt`);
@@ -447,7 +458,7 @@ export class ScratchpadService {
     const scratchFile: ScratchFile = {
       id,
       name: fileName,
-      content: '',
+      backingFileName: this.getCanonicalBackingFileName(id, fileName),
       language,
       parentId: parentFolderId,
       createdAt: Date.now(),
@@ -455,8 +466,8 @@ export class ScratchpadService {
       order: this.getNextOrderIndex()
     };
 
+    await this.saveFileContent(id, '', scratchFile);
     this.scratchFiles.set(id, scratchFile);
-    await this.saveFileContent(id, '');
     await this.saveMetadata();
 
     return scratchFile;
@@ -465,9 +476,9 @@ export class ScratchpadService {
   async updateFileContent(id: string, content: string): Promise<void> {
     const file = this.scratchFiles.get(id);
     if (file) {
-      file.content = content;
-      file.lastModified = Date.now();
-      await this.saveFileContent(id, content);
+      const lastModified = Date.now();
+      await this.saveFileContent(id, content, file);
+      file.lastModified = lastModified;
       await this.saveMetadata();
     }
   }
@@ -489,31 +500,8 @@ export class ScratchpadService {
       return;
     }
 
-    const oldPath = this.getFilePath(id);
     file.name = targetName;
     file.lastModified = Date.now();
-    const newPath = this.getFilePath(id);
-
-    try {
-      const exists = await fs.promises
-        .access(oldPath, fs.constants.F_OK)
-        .then(() => true)
-        .catch(() => false);
-      if (exists) {
-        // Disallow collisions
-        const newExists = await fs.promises
-          .access(newPath, fs.constants.F_OK)
-          .then(() => true)
-          .catch(() => false);
-        if (newExists) {
-          throw new Error('A scratchpad with the same name already exists');
-        }
-        await fs.promises.rename(oldPath, newPath);
-      }
-    } catch (error) {
-      console.error('Failed to rename file:', error);
-      throw error;
-    }
 
     await this.saveMetadata();
   }
@@ -550,25 +538,14 @@ export class ScratchpadService {
 
     await this.saveMetadata();
   }
+
   async deleteScratchFile(id: string): Promise<void> {
     const file = this.scratchFiles.get(id);
     if (!file) {
       return;
     }
 
-    const filePath = this.getFilePath(id);
-
-    try {
-      const exists = await fs.promises
-        .access(filePath, fs.constants.F_OK)
-        .then(() => true)
-        .catch(() => false);
-      if (exists) {
-        await fs.promises.unlink(filePath);
-      }
-    } catch (error) {
-      console.error('Failed to delete file:', error);
-    }
+    await this.deleteStoredFile(id);
 
     this.scratchFiles.delete(id);
     await this.saveMetadata();
@@ -618,13 +595,10 @@ export class ScratchpadService {
     return languageMap[extension];
   }
 
-  private async saveFileContent(id: string, content: string): Promise<void> {
-    const filePath = this.getFilePath(id);
-    try {
-      await fs.promises.writeFile(filePath, content, 'utf8');
-    } catch (error) {
-      console.error('Failed to save file content:', error);
-    }
+  private async saveFileContent(id: string, content: string, file?: Pick<ScratchFile, 'id' | 'name' | 'backingFileName'>): Promise<void> {
+    await this.ensureStorageExists();
+    const filePath = file ? this.getStoredFilePath(file) : this.getFilePath(id);
+    await fs.promises.writeFile(filePath, content, 'utf8');
   }
 
   private getNextOrderIndex(): number {
@@ -957,6 +931,134 @@ export class ScratchpadService {
     return Array.from(this.scratchFiles.values()).find(
       f => f.name === name && f.parentId === parentId
     );
+  }
+
+  private async migrateScratchpadData(data: LegacyScratchpadData): Promise<{
+    files: ScratchFile[];
+    folders: ScratchpadFolder[];
+    changed: boolean;
+    legacyContentById: Map<string, string>;
+  }> {
+    let changed = false;
+    let version = data.version;
+    const legacyContentById = new Map<string, string>();
+    let hasLegacyContent = false;
+    let files = data.files.map(file => {
+      const migratedFile = { ...file };
+      if (typeof migratedFile.content === 'string') {
+        legacyContentById.set(migratedFile.id, migratedFile.content);
+        hasLegacyContent = true;
+      }
+      return migratedFile;
+    });
+    let folders = data.folders ? [...data.folders] : [];
+
+    if (version < 2) {
+      files = files.map(file => ({ ...file, parentId: undefined }));
+      folders = [];
+      version = 2;
+      changed = true;
+    }
+
+    if (version < 3) {
+      files = this.assignBackingFileNames(files);
+      version = 3;
+      changed = true;
+    }
+
+    if (hasLegacyContent && version <= CURRENT_SCRATCHPAD_VERSION) {
+      files = files.map(({ content: _content, ...file }) => file);
+      changed = true;
+    }
+
+    return { files, folders, changed, legacyContentById };
+  }
+
+  private assignBackingFileNames(files: LegacyScratchFile[]): LegacyScratchFile[] {
+    const proposedCounts = new Map<string, number>();
+
+    for (const file of files) {
+      const proposed = file.backingFileName ?? file.name;
+      proposedCounts.set(proposed, (proposedCounts.get(proposed) ?? 0) + 1);
+    }
+
+    const usedBackingNames = new Set<string>();
+
+    return files.map(file => {
+      const proposed = file.backingFileName ?? file.name;
+      let backingFileName = proposed;
+
+      if ((proposedCounts.get(proposed) ?? 0) > 1 || usedBackingNames.has(proposed)) {
+        backingFileName = this.getCanonicalBackingFileName(file.id, file.name);
+      }
+
+      usedBackingNames.add(backingFileName);
+
+      return {
+        ...file,
+        backingFileName
+      };
+    });
+  }
+
+  private async ensureBackingFilesExist(files: ScratchFile[], legacyContentById: Map<string, string>): Promise<void> {
+    for (const file of files) {
+      const filePath = this.getStoredFilePath(file);
+      const exists = await this.fileExists(filePath);
+      if (!exists) {
+        const legacyContent = legacyContentById.get(file.id);
+        if (legacyContent === undefined) {
+          throw new Error(`Missing backing file for scratchpad ${file.id}`);
+        }
+
+        await this.saveFileContent(file.id, legacyContent, file);
+      }
+    }
+  }
+
+  private async deleteStoredFile(id: string): Promise<void> {
+    const filePath = this.getFilePath(id);
+
+    try {
+      if (await this.fileExists(filePath)) {
+        await fs.promises.unlink(filePath);
+      }
+    } catch (error) {
+      console.error(`Failed to delete file ${filePath}:`, error);
+    }
+  }
+
+  private getStoredFilePath(file: Pick<ScratchFile, 'id' | 'name' | 'backingFileName'>): string {
+    return path.join(this.scratchpadDirectory, file.backingFileName ?? file.name);
+  }
+
+  private getCanonicalBackingFileName(id: string, displayName: string): string {
+    const extension = path.extname(displayName) || '.txt';
+    return `${id}${extension}`;
+  }
+
+  private getFolderPathSegments(parentId?: string): string[] {
+    const segments: string[] = [];
+    let currentId = parentId;
+
+    while (currentId) {
+      const folder = this.getFolderById(currentId);
+      if (!folder) {
+        break;
+      }
+
+      segments.unshift(folder.name);
+      currentId = folder.parentId;
+    }
+
+    return segments;
+  }
+
+  private async fileExists(filePath: string): Promise<boolean> {
+    return fs.promises
+      .access(filePath, fs.constants.F_OK)
+      .then(() => true)
+      .catch(() => false);
   }
 }
 

--- a/src/features/scratchpads/ScratchpadService.ts
+++ b/src/features/scratchpads/ScratchpadService.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import * as fs from 'fs';
-import { ScratchFile, ScratchpadFolder, ScratchpadData, CURRENT_SCRATCHPAD_VERSION } from './Models';
+import { ScratchFile, ScratchpadFolder, ScratchpadData, CURRENT_SCRATCHPAD_VERSION, MAX_SCRATCH_FILES } from './Models';
 import { NamespacedStorageService, createNamespacedStorage } from '../../common/storage/StorageService';
 
 export class ScratchpadService {
@@ -82,6 +82,22 @@ export class ScratchpadService {
 
   getFolderById(id: string): ScratchpadFolder | undefined {
     return this.folders.find(f => f.id === id);
+  }
+
+  findNextImportFolderName(baseName: string = '_import'): string {
+    const existingNames = this.folders
+      .filter(f => f.name === baseName || f.name.startsWith(baseName + '_'))
+      .map(f => f.name);
+
+    if (!existingNames.includes(baseName)) {
+      return baseName;
+    }
+
+    let counter = 1;
+    while (existingNames.includes(`${baseName}_${counter}`)) {
+      counter++;
+    }
+    return `${baseName}_${counter}`;
   }
 
   async addFolder(name: string, parentId?: string): Promise<ScratchpadFolder> {
@@ -182,8 +198,8 @@ export class ScratchpadService {
       if (targetFolderId) {
         const targetDepth = this.getFolderDepth(targetFolderId);
         const folderDepth = this.getMaxFolderDepth(itemId);
-        if (targetDepth + folderDepth > 5) {
-          throw new Error('Moving this folder would exceed maximum depth (5 levels)');
+        if (targetDepth + folderDepth > 10) {
+          throw new Error('Moving this folder would exceed maximum depth (10 levels)');
         }
       }
 
@@ -292,8 +308,8 @@ export class ScratchpadService {
     if (draggedFolder && targetParentId !== undefined) {
       const targetDepth = this.getFolderDepth(targetParentId);
       const folderDepth = this.getMaxFolderDepth(draggedFolder.id);
-      if (targetDepth + folderDepth > 5) {
-        throw new Error('Moving this folder would exceed maximum depth (5 levels)');
+      if (targetDepth + folderDepth > 10) {
+        throw new Error('Moving this folder would exceed maximum depth (10 levels)');
       }
     }
 
@@ -411,7 +427,7 @@ export class ScratchpadService {
     return path.join(this.scratchpadDirectory, `${id}.txt`);
   }
 
-  async createScratchFile(fileName: string, language?: string): Promise<ScratchFile> {
+  async createScratchFile(fileName: string, language?: string, parentFolderId?: string): Promise<ScratchFile> {
     const id = uuidv4();
 
     const scratchFile: ScratchFile = {
@@ -419,6 +435,7 @@ export class ScratchpadService {
       name: fileName,
       content: '',
       language,
+      parentId: parentFolderId,
       createdAt: Date.now(),
       lastModified: Date.now(),
       order: this.getNextOrderIndex()
@@ -617,4 +634,334 @@ export class ScratchpadService {
     }
     return '';
   }
+
+  // ─── Import from Directory ────────────────────────────────────────────────────
+
+  private static readonly MAX_SCRATCH_FILES = 400;
+  private static readonly MAX_FOLDER_DEPTH = 10;
+  private static readonly TEXT_SAMPLE_BYTES = 8192;
+
+  async importScratchpadsFromDirectory(
+    dirPath: string,
+    parentFolderId?: string,
+    onProgress?: (current: number, total: number, fileName: string) => void
+  ): Promise<ImportResult> {
+    const result: ImportResult = {
+      imported: 0,
+      skipped: 0,
+      overwritten: 0,
+      errors: 0,
+      errorMessages: [],
+      discoveredFiles: [],
+      skippedFiles: [],
+      importedFileIds: []
+    };
+
+    // Collect all text files first (collect all files for discovery, even non-text)
+    const { filesToImport, discoveredFiles, skippedFiles, skippedDueToLimit } = await this.collectTextFiles(dirPath, parentFolderId);
+    result.discoveredFiles = discoveredFiles;
+    result.skippedFiles = [...skippedFiles, ...skippedDueToLimit];
+    result.skipped = result.skippedFiles.length;
+    const total = filesToImport.length;
+
+    // Handle count limit
+    const currentCount = this.scratchFiles.size;
+    const availableSlots = Math.max(0, ScratchpadService.MAX_SCRATCH_FILES - currentCount);
+
+    if (filesToImport.length > availableSlots) {
+      // Sort by path length (shorter first = closer to root) to prioritize shallow files
+      filesToImport.sort((a, b) => {
+        const depth = (p: string) => p.split(path.sep).filter(Boolean).length;
+        return depth(a.absolutePath) - depth(b.absolutePath);
+      });
+    }
+
+    for (let i = 0; i < filesToImport.length; i++) {
+      const fileInfo = filesToImport[i];
+
+      // Check if we've reached the limit
+      if (this.scratchFiles.size >= ScratchpadService.MAX_SCRATCH_FILES) {
+        result.skipped += filesToImport.length - i;
+        result.skippedFiles.push(...filesToImport.slice(i).map(f => f.relativePath + ' (limit reached)'));
+        break;
+      }
+
+      // Report progress
+      if (onProgress) {
+        onProgress(i + 1, total, fileInfo.name);
+      }
+
+      try {
+        const existing = this.findScratchpadByName(fileInfo.name, fileInfo.parentId);
+        if (existing) {
+          // Overwrite content, keep ID
+          await this.updateFileContent(existing.id, fileInfo.content);
+          result.overwritten++;
+        } else {
+          // Create new
+          const scratchFile = await this.createScratchFile(fileInfo.name, fileInfo.language);
+          await this.updateFileContent(scratchFile.id, fileInfo.content);
+          if (fileInfo.parentId) {
+            await this.moveToFolder(scratchFile.id, fileInfo.parentId);
+          }
+          result.imported++;
+          result.importedFileIds.push(scratchFile.id);
+        }
+      } catch (error) {
+        result.errors++;
+        if (result.errorMessages.length < 10) {
+          result.errorMessages.push(`${fileInfo.name}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  buildImportSummary(
+    result: ImportResult,
+    dirPath: string,
+    folderName: string | undefined,
+    parentFolderId?: string
+  ): { summaryContent: string; importedFilePaths: string[] } {
+    const timestamp = new Date().toLocaleString();
+
+    // Build ASCII tree from file list
+    const buildTree = (files: string[]): string => {
+      if (files.length === 0) { return '  (empty)'; }
+      interface TreeNode { [key: string]: TreeNode | string[] | undefined; }
+      const tree: TreeNode = {};
+      for (const f of files) {
+        const parts = f.split('/');
+        let current: TreeNode = tree;
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
+          if (i === parts.length - 1) {
+            if (part === '') {
+              // Path ends with '/' — this is a folder-only entry; node already created above
+              break;
+            }
+            // File
+            if (!current['@files']) { current['@files'] = []; }
+            (current['@files'] as string[]).push(part);
+          } else {
+            // Folder
+            if (!current[part]) { current[part] = {}; }
+            current = current[part] as TreeNode;
+          }
+        }
+      }
+      const render = (node: TreeNode, prefix: string = ''): string => {
+        let output = '';
+        const dirs = Object.keys(node).filter(k => k !== '@files').sort();
+        const files_list = (node['@files'] as string[]) || [];
+        for (let i = 0; i < dirs.length; i++) {
+          const isLast = i === dirs.length - 1 && files_list.length === 0;
+          output += prefix + (isLast ? '└── ' : '├── ') + dirs[i] + '/\n';
+          output += render(node[dirs[i]] as TreeNode, prefix + (isLast ? '    ' : '│   '));
+        }
+        for (let i = 0; i < files_list.length; i++) {
+          const isLast = i === files_list.length - 1;
+          output += prefix + (isLast ? '└── ' : '├── ') + files_list[i] + '\n';
+        }
+        return output;
+      };
+      return render(tree);
+    };
+
+    // Sort discovered and skipped files
+    const discoveredFiles = [...result.discoveredFiles].sort();
+    const skippedFiles = [...result.skippedFiles].sort();
+
+    // Build imported files list with folder structure
+    const importedFiles = result.importedFileIds
+      .map(id => this.scratchFiles.get(id))
+      .filter((f): f is ScratchFile => f !== undefined);
+
+    // Build folder path map (folderId -> path like "src/utils")
+    const folders = this.getFolders();
+    const folderPathMap: { [id: string]: string } = {};
+    const buildFolderPath = (folderId: string): string => {
+      if (folderPathMap[folderId]) { return folderPathMap[folderId]; }
+      const folder = folders.find(f => f.id === folderId);
+      if (!folder) { return ''; }
+      const parentPath = folder.parentId ? buildFolderPath(folder.parentId) : '';
+      const fp = parentPath ? parentPath + '/' + folder.name : folder.name;
+      folderPathMap[folderId] = fp;
+      return fp;
+    };
+
+    // Build imported file paths with folder structure
+    const importedFilePaths: string[] = [];
+    for (const file of importedFiles) {
+      const fp = file.parentId ? buildFolderPath(file.parentId) : '';
+      importedFilePaths.push(fp ? fp + '/' + file.name : file.name);
+    }
+    importedFilePaths.sort();
+
+    let summaryContent = `# Import Summary - ${timestamp}\n\n` +
+      `**Source:** \`${dirPath}\`\n` +
+      `**Folder:** ${folderName ?? 'Root'}\n\n` +
+      `## Results\n` +
+      `- Imported: ${result.imported}\n` +
+      (result.overwritten > 0 ? `- Overwritten: ${result.overwritten}\n` : '') +
+      (result.skipped > 0 ? `- Skipped: ${result.skipped}\n` : '') +
+      (result.errors > 0 ? `- Errors: ${result.errors}\n` : '') +
+      '\n## Discovered Files (' + discoveredFiles.filter(f => !f.endsWith('/')).length + ')\n```\n' + buildTree(discoveredFiles) + '```\n';
+    if (skippedFiles.length > 0) {
+      summaryContent += '\n## Skipped Files (' + skippedFiles.length + ')\n```\n' + buildTree(skippedFiles) + '```\n';
+    }
+    summaryContent += '\n## Imported Files (' + importedFiles.length + ')\n```\n' + buildTree(importedFilePaths) + '```\n';
+    if (result.errors > 0 && result.errorMessages.length > 0) {
+      summaryContent += '\n## Errors\n';
+      for (const err of result.errorMessages) {
+        summaryContent += `- ${err}\n`;
+      }
+    }
+
+    return { summaryContent, importedFilePaths };
+  }
+
+  private async collectTextFiles(
+    dirPath: string,
+    parentFolderId?: string,
+    prefix: string = ''
+  ): Promise<{
+    filesToImport: ImportFileInfo[];
+    discoveredFiles: string[];
+    skippedFiles: string[];
+    skippedDueToLimit: string[];
+  }> {
+    const files: ImportFileInfo[] = [];
+    const discoveredFiles: string[] = [];
+    const skippedFiles: string[] = [];
+    const skippedDueToLimit: string[] = [];
+    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+
+      // Skip symlinks
+      try {
+        const stat = await fs.promises.lstat(fullPath);
+        if (stat.isSymbolicLink()) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        // Create or find folder, then recurse
+        let folderId = parentFolderId;
+        const depth = parentFolderId ? this.getFolderDepth(parentFolderId) : 0;
+        if (depth < ScratchpadService.MAX_FOLDER_DEPTH) {
+          // Check if folder exists at this level
+          const existingFolder = this.folders.find(
+            f => f.name === entry.name && f.parentId === parentFolderId
+          );
+          if (existingFolder) {
+            folderId = existingFolder.id;
+          } else {
+            const created = await this.addFolder(entry.name, parentFolderId);
+            folderId = created.id;
+          }
+          // Discover directory in tree
+          discoveredFiles.push(prefix + entry.name + '/');
+          const childResult = await this.collectTextFiles(fullPath, folderId, prefix + entry.name + '/');
+          files.push(...childResult.filesToImport);
+          discoveredFiles.push(...childResult.discoveredFiles);
+          skippedFiles.push(...childResult.skippedFiles);
+          skippedDueToLimit.push(...childResult.skippedDueToLimit);
+        } else {
+          // Exceed depth, import files into deepest valid folder
+          const childResult = await this.collectTextFiles(fullPath, folderId, prefix + entry.name + '/');
+          files.push(...childResult.filesToImport);
+          discoveredFiles.push(...childResult.discoveredFiles);
+          skippedFiles.push(...childResult.skippedFiles);
+          skippedDueToLimit.push(...childResult.skippedDueToLimit);
+        }
+      } else if (entry.isFile()) {
+        // Check if text file
+        const isText = await this.isTextFile(fullPath);
+        const relativePath = prefix + entry.name;
+        discoveredFiles.push(relativePath);
+        if (!isText) {
+          skippedFiles.push(relativePath + ' (binary)');
+          continue;
+        }
+
+        // Read content
+        let content = '';
+        try {
+          content = await fs.promises.readFile(fullPath, 'utf8');
+        } catch {
+          skippedFiles.push(relativePath + ' (read error)');
+          continue;
+        }
+
+        // Detect language
+        const language = this.getLanguageFromExtension(path.extname(entry.name));
+
+        files.push({
+          name: entry.name,
+          content,
+          language,
+          parentId: parentFolderId,
+          absolutePath: fullPath,
+          relativePath
+        });
+      }
+    }
+
+    return { filesToImport: files, discoveredFiles, skippedFiles, skippedDueToLimit };
+  }
+
+  private async isTextFile(filePath: string): Promise<boolean> {
+    let fd: import('fs').promises.FileHandle | undefined;
+    try {
+      fd = await fs.promises.open(filePath, 'r');
+      const buffer = Buffer.alloc(ScratchpadService.TEXT_SAMPLE_BYTES);
+      const { bytesRead } = await fd.read(buffer, 0, ScratchpadService.TEXT_SAMPLE_BYTES, 0);
+      // Check for null bytes in the sample
+      for (let i = 0; i < bytesRead; i++) {
+        if (buffer[i] === 0) {
+          return false;
+        }
+      }
+      return true;
+    } catch {
+      return false;
+    } finally {
+      if (fd) {
+        await fd.close();
+      }
+    }
+  }
+
+  private findScratchpadByName(name: string, parentId?: string): ScratchFile | undefined {
+    return Array.from(this.scratchFiles.values()).find(
+      f => f.name === name && f.parentId === parentId
+    );
+  }
+}
+
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  overwritten: number;
+  errors: number;
+  errorMessages: string[];
+  discoveredFiles: string[];
+  skippedFiles: string[];
+  importedFileIds: string[];
+}
+
+interface ImportFileInfo {
+  name: string;
+  content: string;
+  language?: string;
+  parentId?: string;
+  absolutePath: string;
+  relativePath: string;
 }

--- a/src/features/scratchpads/ScratchpadValidator.ts
+++ b/src/features/scratchpads/ScratchpadValidator.ts
@@ -1,5 +1,7 @@
+import { MAX_SCRATCH_FILES } from './Models';
+
 export default class ScratchpadValidator {
-  private static readonly MAX_TOTAL_FILES = 200;
+  private static readonly MAX_TOTAL_FILES = MAX_SCRATCH_FILES;
   private static readonly MIN_FOLDER_NAME_LENGTH = 1;
   private static readonly MAX_FOLDER_NAME_LENGTH = 75;
   private static readonly MIN_FILE_NAME_LENGTH = 1;

--- a/src/features/scratchpads/ScratchpadsProvider.ts
+++ b/src/features/scratchpads/ScratchpadsProvider.ts
@@ -2,9 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { ScratchpadItem } from './views/ScratchpadItem';
 import { ScratchpadFolderTreeItem } from './views/ScratchpadFolderTreeItem';
-import { ScratchpadService } from './ScratchpadService';
+import { ScratchpadService, ImportResult } from './ScratchpadService';
 import { ScratchpadFolder } from './Models';
-import ScratchpadValidator from './ScratchpadValidator';
 
 const LANGUAGE_TO_EXTENSION: Record<string, string> = {
   javascript: '.js',
@@ -141,20 +140,12 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
   }
 
   async addFolder(name: string, parentId?: string): Promise<ScratchpadFolder> {
-    const error = ScratchpadValidator.validateFolderName(name);
-    if (error) {
-      throw new Error(error);
-    }
     const folder = await this.scratchpadService.addFolder(name, parentId);
     this.refresh();
     return folder;
   }
 
   async editFolder(id: string, name: string): Promise<void> {
-    const error = ScratchpadValidator.validateFolderName(name);
-    if (error) {
-      throw new Error(error);
-    }
     await this.scratchpadService.editFolder(id, name);
     this.refresh();
   }
@@ -229,7 +220,6 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
     let fileName: string;
     if (params.name && params.name.trim().length > 0) {
       fileName = this.normalizeFileName(params.name.trim(), extension);
-      this.validateFileName(fileName);
       const exists = this.scratchpadService.getScratchFiles().some(f => f.name === fileName);
       if (exists) {
         throw new Error('A scratchpad with this name already exists.');
@@ -238,7 +228,6 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
       const fileNumber = this.scratchpadService.getNextFileNumber(extension);
       fileName = `scratchpad_${fileNumber}${extension}`;
     }
-
     const language = params.language || this.scratchpadService.getLanguageFromExtension(path.extname(fileName));
     const scratchFile = await this.scratchpadService.createScratchFile(fileName, language);
     if (content.length > 0) {
@@ -260,8 +249,6 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
     if (trimmed.length === 0) {
       throw new Error('File name cannot be empty.');
     }
-
-    this.validateFileName(trimmed);
 
     const providedExt = path.extname(trimmed);
     const oldExt = path.extname(file.name);
@@ -291,6 +278,33 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
   async deleteScratchFileForTools(id: string): Promise<void> {
     await this.scratchpadService.deleteScratchFile(id);
     this.refresh();
+  }
+
+  async importScratchpadsFromDirectory(
+    dirPath: string,
+    parentFolderId?: string
+  ): Promise<ImportResult> {
+    const result = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Importing Scratchpads',
+        cancellable: false
+      },
+      async (progress) => {
+        return this.scratchpadService.importScratchpadsFromDirectory(
+          dirPath,
+          parentFolderId,
+          (current, total, fileName) => {
+            progress.report({
+              message: `${current}/${total}: ${fileName}`,
+              increment: Math.floor(100 / total)
+            });
+          }
+        );
+      }
+    );
+    this.refresh();
+    return result;
   }
 
   async saveActiveUnsavedEditorAsScratchpad(): Promise<void> {
@@ -455,12 +469,6 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
       return fileName;
     }
     return `${fileName}${extension}`;
-  }
-
-  private validateFileName(fileName: string): void {
-    if (!/^[a-zA-Z0-9_\-. ]+$/.test(fileName)) {
-      throw new Error('File name contains invalid characters.');
-    }
   }
 
   private getExtensionForDocument(document: vscode.TextDocument): string {

--- a/src/features/scratchpads/ScratchpadsProvider.ts
+++ b/src/features/scratchpads/ScratchpadsProvider.ts
@@ -151,6 +151,33 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
   }
 
   async deleteFolder(id: string): Promise<void> {
+    await this.deleteFolderWithConfirmation(id);
+  }
+
+  async deleteFolderForTools(id: string): Promise<void> {
+    await this.scratchpadService.deleteFolder(id);
+    this.refresh();
+  }
+
+  private async deleteFolderWithConfirmation(id: string): Promise<void> {
+    const folder = this.scratchpadService.getFolderById(id);
+    if (!folder) {
+      return;
+    }
+
+    const itemCount = this.scratchpadService.countFolderItems(id);
+    const result = await vscode.window.showWarningMessage(
+      itemCount > 0
+        ? `Are you sure you want to delete "${folder.name}"? This will delete ${itemCount} item(s) including all subfolders and scratchpads.`
+        : `Are you sure you want to delete "${folder.name}"?`,
+      { modal: true },
+      'Delete'
+    );
+
+    if (result !== 'Delete') {
+      return;
+    }
+
     await this.scratchpadService.deleteFolder(id);
     this.refresh();
   }

--- a/src/features/scratchpads/ScratchpadsProvider.ts
+++ b/src/features/scratchpads/ScratchpadsProvider.ts
@@ -36,17 +36,24 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
 
   public scratchpadService: ScratchpadService;
   private openDocuments: Map<string, vscode.TextDocument> = new Map();
+  private loadPromise: Promise<void>;
 
   constructor(private context: vscode.ExtensionContext, scratchpadService?: ScratchpadService) {
     this.scratchpadService = scratchpadService || new ScratchpadService(context);
-    this.loadScratchFiles().catch(console.error);
+    this.loadPromise = this.loadScratchFiles();
+    this.loadPromise.catch(console.error);
     context.subscriptions.push(
       vscode.workspace.onDidChangeTextDocument(this.onDocumentChange, this),
       vscode.workspace.onDidCloseTextDocument(this.onDocumentClose, this),
       vscode.workspace.onDidChangeWorkspaceFolders(() => {
-        this.loadScratchFiles().catch(console.error);
+        this.loadPromise = this.loadScratchFiles();
+        this.loadPromise.catch(console.error);
       })
     );
+  }
+
+  async whenReady(): Promise<void> {
+    await this.loadPromise;
   }
 
   getTreeItem(element: TreeItem): vscode.TreeItem {
@@ -187,7 +194,7 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
     this.refresh();
   }
 
-  async createScratchFile(): Promise<void> {
+  async createScratchFile(parentFolderId?: string): Promise<void> {
     // For now, simple list of file types
     const fileTypes = [
       { label: 'JavaScript', extension: '.js' },
@@ -220,7 +227,7 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
       return;
     }
 
-    await this.createScratchpadFromExtension(selected.extension);
+    await this.createScratchpadFromExtension(selected.extension, '', parentFolderId);
   }
 
   getAllScratchpads() {
@@ -256,12 +263,9 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
       fileName = `scratchpad_${fileNumber}${extension}`;
     }
     const language = params.language || this.scratchpadService.getLanguageFromExtension(path.extname(fileName));
-    const scratchFile = await this.scratchpadService.createScratchFile(fileName, language);
+    const scratchFile = await this.scratchpadService.createScratchFile(fileName, language, params.parentFolderId);
     if (content.length > 0) {
       await this.scratchpadService.updateFileContent(scratchFile.id, content);
-    }
-    if (params.parentFolderId) {
-      await this.scratchpadService.moveToFolder(scratchFile.id, params.parentFolderId);
     }
     this.refresh();
   }
@@ -466,12 +470,12 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
     this.refresh();
   }
 
-  private async createScratchpadFromExtension(extension: string, content = ''): Promise<void> {
+  private async createScratchpadFromExtension(extension: string, content = '', parentFolderId?: string): Promise<void> {
     const fileNumber = this.scratchpadService.getNextFileNumber(extension);
     const fileName = `scratchpad_${fileNumber}${extension}`;
     const language = this.scratchpadService.getLanguageFromExtension(extension);
 
-    const scratchFile = await this.scratchpadService.createScratchFile(fileName, language);
+    const scratchFile = await this.scratchpadService.createScratchFile(fileName, language, parentFolderId);
     if (content.length > 0) {
       await this.scratchpadService.updateFileContent(scratchFile.id, content);
     }

--- a/src/features/scratchpads/ScratchpadsProvider.ts
+++ b/src/features/scratchpads/ScratchpadsProvider.ts
@@ -361,8 +361,7 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
       return;
     }
 
-    const filePath = this.scratchpadService.getFilePath(id);
-    const uri = vscode.Uri.file(filePath);
+    const uri = this.scratchpadService.getScratchpadUri(id);
 
     const doc = await vscode.workspace.openTextDocument(uri);
     this.openDocuments.set(id, doc);
@@ -539,6 +538,15 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
   }
 
   private async onDocumentChange(event: vscode.TextDocumentChangeEvent): Promise<void> {
+    const scratchpadId = this.scratchpadService.getScratchpadIdFromUri(event.document.uri);
+    if (scratchpadId) {
+      this.openDocuments.set(scratchpadId, event.document);
+      const content = event.document.getText();
+      await this.scratchpadService.updateFileContent(scratchpadId, content);
+      this.refresh();
+      return;
+    }
+
     for (const [id, doc] of this.openDocuments) {
       if (doc.uri.toString() === event.document.uri.toString()) {
         const content = event.document.getText();
@@ -550,6 +558,12 @@ export class ScratchpadsProvider implements vscode.TreeDataProvider<TreeItem> {
   }
 
   private onDocumentClose(document: vscode.TextDocument): void {
+    const scratchpadId = this.scratchpadService.getScratchpadIdFromUri(document.uri);
+    if (scratchpadId) {
+      this.openDocuments.delete(scratchpadId);
+      return;
+    }
+
     for (const [id, doc] of this.openDocuments) {
       if (doc.uri.toString() === document.uri.toString()) {
         this.openDocuments.delete(id);

--- a/src/features/scratchpads/index.ts
+++ b/src/features/scratchpads/index.ts
@@ -1,4 +1,5 @@
 export { ScratchpadsProvider } from './ScratchpadsProvider';
+export { ScratchpadFileSystemProvider } from './ScratchpadFileSystemProvider';
 export { registerScratchpadCommands } from './ScratchpadCommands';
 export { registerScratchpadAiTools } from './ScratchpadAiTools';
 export { ScratchpadService } from './ScratchpadService';

--- a/src/test/features/scratchpad-filesystem-provider.test.ts
+++ b/src/test/features/scratchpad-filesystem-provider.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ScratchpadFileSystemProvider } from '../../features/scratchpads/ScratchpadFileSystemProvider';
+
+suite('ScratchpadFileSystemProvider', () => {
+  test('readFile waits for scratchpads to finish loading', async () => {
+    let ready = false;
+    let resolveReady: (() => void) | undefined;
+    const whenReady = new Promise<void>(resolve => {
+      resolveReady = resolve;
+    });
+
+    const provider = new ScratchpadFileSystemProvider({
+      whenReady: () => whenReady,
+      scratchpadService: {
+        getScratchpadIdFromUri: () => 'scratch-1',
+        getScratchFile: () => ready ? {
+          id: 'scratch-1',
+          name: 'notes.md',
+          createdAt: 1,
+          lastModified: 2
+        } : undefined,
+        loadFileContent: () => '# restored'
+      }
+    } as any);
+
+    const uri = vscode.Uri.from({
+      scheme: 'codebench-scratchpad',
+      path: '/notes.md',
+      query: 'id=scratch-1'
+    });
+
+    let settled = false;
+    const readPromise = provider.readFile(uri).then(result => {
+      settled = true;
+      return result;
+    });
+
+    await Promise.resolve();
+    assert.strictEqual(settled, false, 'readFile should wait for scratchpad loading');
+
+    ready = true;
+    resolveReady?.();
+
+    const bytes = await readPromise;
+    assert.strictEqual(new TextDecoder().decode(bytes), '# restored');
+  });
+});

--- a/src/test/features/scratchpad-import.test.ts
+++ b/src/test/features/scratchpad-import.test.ts
@@ -1,0 +1,414 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ScratchpadService, ImportResult } from '../../features/scratchpads/ScratchpadService';
+import { createMockExtensionContext } from '../testUtils';
+
+suite('ScratchpadService - import from directory', () => {
+  let mockContext: any;
+  let service: ScratchpadService;
+  let tempDir: string;
+
+  setup(async () => {
+    mockContext = createMockExtensionContext();
+    service = new ScratchpadService(mockContext);
+    await service.loadScratchFiles();
+    tempDir = path.join(process.cwd(), '.test-import-' + Date.now());
+    fs.mkdirSync(tempDir, { recursive: true });
+  });
+
+  teardown(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    try {
+      const tempRoot = path.dirname(mockContext.globalStorageUri.fsPath);
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function createFile(filePath: string, content: string): void {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(filePath, content, 'utf8');
+  }
+
+  function createBinaryFile(filePath: string, buffer: Buffer): void {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(filePath, buffer);
+  }
+
+  suite('importScratchpadsFromDirectory', () => {
+    test('imports text files from a directory', async () => {
+      createFile(path.join(tempDir, 'file1.txt'), 'hello world');
+      createFile(path.join(tempDir, 'file2.md'), '# Markdown content');
+
+      // Verify files exist
+      assert.ok(fs.existsSync(path.join(tempDir, 'file1.txt')), 'file1.txt should exist');
+      assert.ok(fs.existsSync(path.join(tempDir, 'file2.md')), 'file2.md should exist');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 2);
+      assert.strictEqual(result.skipped, 0);
+      assert.strictEqual(result.overwritten, 0);
+      const files = service.getScratchFiles();
+      assert.strictEqual(files.length, 2);
+      const names = files.map(f => f.name).sort();
+      assert.deepStrictEqual(names, ['file1.txt', 'file2.md']);
+    });
+
+    test('skips binary files', async () => {
+      createFile(path.join(tempDir, 'text.txt'), 'hello world');
+      // PDF-like binary: valid bytes then null at position 5
+      const binaryBuffer = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x0A, 0x00, 0x00, 0x00]);
+      createBinaryFile(path.join(tempDir, 'binary.pdf'), binaryBuffer);
+      createFile(path.join(tempDir, 'code.js'), 'const x = 1;');
+
+      // Verify the binary file has null bytes within first 8KB
+      const binaryContent = fs.readFileSync(path.join(tempDir, 'binary.pdf'));
+      assert.ok(binaryContent.includes(0x00), 'binary.pdf should contain null bytes');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      // text.txt and code.js should import; binary.pdf should be skipped
+      assert.strictEqual(result.imported, 2, `imported=${result.imported}, errors=${result.errorMessages.join('; ')}`);
+      assert.strictEqual(result.skipped, 1, `skipped=${result.skipped}`);
+    });
+
+    test('mirrors directory structure as folders', async () => {
+      const subDir = path.join(tempDir, 'src');
+      fs.mkdirSync(subDir, { recursive: true });
+      createFile(path.join(tempDir, 'root.txt'), 'root file');
+      createFile(path.join(subDir, 'nested.txt'), 'nested file');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 2);
+      const folders = service.getFolders();
+      assert.strictEqual(folders.length, 1);
+      assert.strictEqual(folders[0].name, 'src');
+      const rootFile = service.getScratchFiles().find(f => f.name === 'root.txt');
+      const nestedFile = service.getScratchFiles().find(f => f.name === 'nested.txt');
+      assert.strictEqual(rootFile?.parentId, undefined);
+      assert.strictEqual(nestedFile?.parentId, folders[0].id);
+    });
+
+    test('handles deep nested directories (depth > 10) by flattening', async () => {
+      // Create a 12-level deep structure: d1/d2/.../d12/file.txt
+      // This exceeds the 10-level limit, so d1-d10 are created and file goes into d10
+      let current = tempDir;
+      const parts = ['d1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8', 'd9', 'd10', 'd11', 'd12'];
+      for (const part of parts) {
+        current = path.join(current, part);
+        fs.mkdirSync(current, { recursive: true });
+      }
+      createFile(path.join(current, 'deep.txt'), 'deep content');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      // Should still import successfully, flattening into deepest valid folder (d10)
+      assert.strictEqual(result.imported, 1);
+      const folders = service.getFolders();
+      // d1 through d10 should be created (depth 10 = max allowed)
+      assert.strictEqual(folders.length, 10);
+      const deepFile = service.getScratchFiles().find(f => f.name === 'deep.txt');
+      assert.ok(deepFile, 'deep.txt should be imported');
+      // Parent should be d10 (the deepest valid folder)
+      assert.strictEqual(deepFile?.parentId, folders[9].id);
+    });
+
+    test('imports dotfiles (hidden files)', async () => {
+      createFile(path.join(tempDir, '.env'), 'API_KEY=secret');
+      createFile(path.join(tempDir, '.gitignore'), 'node_modules/');
+      createFile(path.join(tempDir, 'readme.md'), '# Hello');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 3);
+      const files = service.getScratchFiles();
+      const names = files.map(f => f.name);
+      assert.ok(names.includes('.env'));
+      assert.ok(names.includes('.gitignore'));
+      assert.ok(names.includes('readme.md'));
+    });
+
+    test('skips symlinks', async () => {
+      createFile(path.join(tempDir, 'real.txt'), 'real content');
+      const symlinkPath = path.join(tempDir, 'link.txt');
+      try {
+        fs.symlinkSync(path.join(tempDir, 'real.txt'), symlinkPath);
+      } catch {
+        // symlinks may not work in all environments
+      }
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      // Should import at least real.txt (symlink may fail to create)
+      assert.ok(result.imported >= 1);
+    });
+
+    test('overwrites existing scratchpad with same name in same folder', async () => {
+      const existing = await service.createScratchFile('file.txt', 'plaintext');
+      await service.updateFileContent(existing.id, 'old content');
+
+      createFile(path.join(tempDir, 'file.txt'), 'new content');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 0);
+      assert.strictEqual(result.overwritten, 1);
+      const updated = service.getScratchFile(existing.id)!;
+      assert.strictEqual(updated.content, 'new content');
+      // Should still be the same file (same ID)
+      assert.strictEqual(updated.id, existing.id);
+    });
+
+    test('reports correct count when limit is reached', async () => {
+      // Create 150 files (well under the 200 limit)
+      for (let i = 0; i < 150; i++) {
+        createFile(path.join(tempDir, `file${i}.txt`), `content ${i}`);
+      }
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 150);
+      assert.strictEqual(result.skipped, 0);
+    });
+
+    test('reports errors for unreadable files', async () => {
+      createFile(path.join(tempDir, 'valid.txt'), 'valid content');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      // Should not have errors for valid files
+      assert.strictEqual(result.errors, 0);
+      assert.ok(result.errorMessages.length === 0);
+    });
+
+    test('can import into a specific parent folder', async () => {
+      const parentFolder = await service.addFolder('ImportTarget');
+      createFile(path.join(tempDir, 'file.txt'), 'file content');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir, parentFolder.id);
+
+      assert.strictEqual(result.imported, 1);
+      const files = service.getScratchFiles();
+      assert.strictEqual(files.length, 1);
+      assert.strictEqual(files[0].parentId, parentFolder.id);
+    });
+
+    test('returns correct language from extension', async () => {
+      createFile(path.join(tempDir, 'script.js'), 'const x = 1;');
+      createFile(path.join(tempDir, 'data.json'), '{"key": "value"}');
+      createFile(path.join(tempDir, 'doc.md'), '# Title');
+
+      await service.importScratchpadsFromDirectory(tempDir);
+
+      const jsFile = service.getScratchFiles().find(f => f.name === 'script.js');
+      const jsonFile = service.getScratchFiles().find(f => f.name === 'data.json');
+      const mdFile = service.getScratchFiles().find(f => f.name === 'doc.md');
+      assert.strictEqual(jsFile?.language, 'javascript');
+      assert.strictEqual(jsonFile?.language, 'json');
+      assert.strictEqual(mdFile?.language, 'markdown');
+    });
+
+    test('empty directory returns zero imported', async () => {
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 0);
+      assert.strictEqual(result.skipped, 0);
+      assert.strictEqual(result.overwritten, 0);
+      assert.strictEqual(result.errors, 0);
+    });
+
+    test('skips files with null bytes in content', async () => {
+      // Plain text file with null byte embedded early
+      const binaryBuffer = Buffer.from([0x74, 0x65, 0x78, 0x74, 0x00, 0x62, 0x69, 0x6e]);
+      createBinaryFile(path.join(tempDir, 'bad.txt'), binaryBuffer);
+
+      // Verify null byte is present
+      const content = fs.readFileSync(path.join(tempDir, 'bad.txt'));
+      assert.ok(content.includes(0x00), 'bad.txt should contain null byte');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 0, `imported=${result.imported}, errors=${result.errorMessages.join('; ')}`);
+      assert.strictEqual(result.skipped, 1, `skipped=${result.skipped}`);
+    });
+
+    test('progress callback is called for each file', async () => {
+      createFile(path.join(tempDir, 'a.txt'), 'content a');
+      createFile(path.join(tempDir, 'b.txt'), 'content b');
+      createFile(path.join(tempDir, 'c.txt'), 'content c');
+
+      const progressCalls: { current: number; total: number; fileName: string }[] = [];
+      await service.importScratchpadsFromDirectory(
+        tempDir,
+        undefined,
+        (current, total, fileName) => {
+          progressCalls.push({ current, total, fileName });
+        }
+      );
+
+      assert.strictEqual(progressCalls.length, 3);
+      assert.strictEqual(progressCalls[0].current, 1);
+      assert.strictEqual(progressCalls[0].total, 3);
+      assert.strictEqual(progressCalls[0].fileName, 'a.txt');
+      assert.strictEqual(progressCalls[1].current, 2);
+      assert.strictEqual(progressCalls[1].fileName, 'b.txt');
+      assert.strictEqual(progressCalls[2].current, 3);
+      assert.strictEqual(progressCalls[2].fileName, 'c.txt');
+    });
+
+    test('multiple directories in import keep correct folder structure', async () => {
+      const srcDir = path.join(tempDir, 'src');
+      const libDir = path.join(tempDir, 'lib');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.mkdirSync(libDir, { recursive: true });
+      createFile(path.join(srcDir, 'main.js'), '// main');
+      createFile(path.join(libDir, 'util.js'), '// util');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 2);
+      const folders = service.getFolders();
+      const folderNames = folders.map(f => f.name).sort();
+      assert.deepStrictEqual(folderNames, ['lib', 'src']);
+      const mainFile = service.getScratchFiles().find(f => f.name === 'main.js');
+      const libFile = service.getScratchFiles().find(f => f.name === 'util.js');
+      const srcFolder = folders.find(f => f.name === 'src')!;
+      const libFolder = folders.find(f => f.name === 'lib')!;
+      assert.strictEqual(mainFile?.parentId, srcFolder.id);
+      assert.strictEqual(libFile?.parentId, libFolder.id);
+    });
+
+    test('skips large files with null byte near 8KB boundary', async () => {
+      // Create a file larger than 8KB with null byte at position 8000
+      const largeContent = Buffer.alloc(8500, 'x'.charCodeAt(0));
+      largeContent[8000] = 0; // null byte near end of first 8KB sample
+      createBinaryFile(path.join(tempDir, 'large.bin'), largeContent);
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 0);
+      assert.strictEqual(result.skipped, 1);
+    });
+
+    test('imports whitespace-only files', async () => {
+      createFile(path.join(tempDir, 'empty.txt'), '');
+      createFile(path.join(tempDir, 'spaces.txt'), '   ');
+      createFile(path.join(tempDir, 'tabs.txt'), '\t\t');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 3);
+      const files = service.getScratchFiles();
+      assert.strictEqual(files.length, 3);
+    });
+
+    test('imports files with unicode content', async () => {
+      createFile(path.join(tempDir, 'emoji.txt'), 'Hello 👋 🌍');
+      createFile(path.join(tempDir, 'unicode.txt'), '日本語テスト');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 2);
+      const content = service.loadFileContent(service.getScratchFiles().find(f => f.name === 'emoji.txt')!.id);
+      assert.ok(content.includes('👋'));
+    });
+
+    test('correctly handles import when limit is reached mid-process', async () => {
+      // Create 402 files (exceeds 400 limit by 2)
+      for (let i = 0; i < 402; i++) {
+        createFile(path.join(tempDir, `file${i}.txt`), `content ${i}`);
+      }
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      // 400 should import, 2 should be skipped
+      assert.strictEqual(result.imported, 400);
+      assert.strictEqual(result.skipped, 2);
+    });
+
+    test('reuses existing folders during import instead of recreating', async () => {
+      // Pre-create a folder structure
+      const existingFolder = await service.addFolder('existing');
+      createFile(path.join(tempDir, 'file1.txt'), 'content 1');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 1);
+      const folders = service.getFolders();
+      // Should still have exactly 1 folder (existing), not created a new one
+      assert.strictEqual(folders.length, 1);
+      assert.strictEqual(folders[0].name, 'existing');
+    });
+
+    test('preserves multi-level folder nesting', async () => {
+      // Create a 3-level deep structure: a/b/c/file.txt
+      const subDir = path.join(tempDir, 'a', 'b', 'c');
+      fs.mkdirSync(subDir, { recursive: true });
+      createFile(path.join(subDir, 'nested.txt'), 'deeply nested content');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 1);
+      const folders = service.getFolders();
+      assert.strictEqual(folders.length, 3);
+      const names = folders.map(f => f.name).sort();
+      assert.deepStrictEqual(names, ['a', 'b', 'c']);
+      const nestedFile = service.getScratchFiles().find(f => f.name === 'nested.txt');
+      assert.ok(nestedFile, 'file should be imported');
+      // Parent should be 'c' folder
+      const cFolder = folders.find(f => f.name === 'c');
+      assert.strictEqual(nestedFile?.parentId, cFolder?.id);
+    });
+
+    test('detects language for uncommon extensions', async () => {
+      createFile(path.join(tempDir, 'script.py'), 'print("hello")');
+      createFile(path.join(tempDir, 'program.go'), 'package main');
+      createFile(path.join(tempDir, 'code.rs'), 'fn main() {}');
+      createFile(path.join(tempDir, 'shell.sh'), '#!/bin/bash');
+
+      await service.importScratchpadsFromDirectory(tempDir);
+
+      const pyFile = service.getScratchFiles().find(f => f.name === 'script.py');
+      const goFile = service.getScratchFiles().find(f => f.name === 'program.go');
+      const rsFile = service.getScratchFiles().find(f => f.name === 'code.rs');
+      const shFile = service.getScratchFiles().find(f => f.name === 'shell.sh');
+      assert.strictEqual(pyFile?.language, 'python');
+      assert.strictEqual(goFile?.language, 'go');
+      assert.strictEqual(rsFile?.language, 'rust');
+      assert.strictEqual(shFile?.language, 'shellscript');
+    });
+
+    test('findNextImportFolderName returns _import when no folders exist', async () => {
+      const name = service.findNextImportFolderName();
+      assert.strictEqual(name, '_import');
+    });
+
+    test('findNextImportFolderName increments when _import exists', async () => {
+      await service.addFolder('_import', undefined);
+      const name = service.findNextImportFolderName();
+      assert.strictEqual(name, '_import_1');
+    });
+
+    test('findNextImportFolderName finds next available number', async () => {
+      await service.addFolder('_import', undefined);
+      await service.addFolder('_import_1', undefined);
+      await service.addFolder('_import_3', undefined);
+      const name = service.findNextImportFolderName();
+      assert.strictEqual(name, '_import_2');
+    });
+  });
+});

--- a/src/test/features/scratchpad-import.test.ts
+++ b/src/test/features/scratchpad-import.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ScratchpadService, ImportResult } from '../../features/scratchpads/ScratchpadService';
+import { createNamespacedStorage } from '../../common/storage/StorageService';
 import { createMockExtensionContext } from '../testUtils';
 
 suite('ScratchpadService - import from directory', () => {
@@ -168,9 +169,34 @@ suite('ScratchpadService - import from directory', () => {
       assert.strictEqual(result.imported, 0);
       assert.strictEqual(result.overwritten, 1);
       const updated = service.getScratchFile(existing.id)!;
-      assert.strictEqual(updated.content, 'new content');
+      assert.strictEqual(service.loadFileContent(updated.id), 'new content');
       // Should still be the same file (same ID)
       assert.strictEqual(updated.id, existing.id);
+    });
+
+    test('keeps same-named files in different folders isolated', async () => {
+      const folderA = path.join(tempDir, 'a');
+      const folderB = path.join(tempDir, 'b');
+      fs.mkdirSync(folderA, { recursive: true });
+      fs.mkdirSync(folderB, { recursive: true });
+
+      createFile(path.join(folderA, 'notes.md'), '# Folder A');
+      createFile(path.join(folderB, 'notes.md'), '# Folder B');
+
+      const result = await service.importScratchpadsFromDirectory(tempDir);
+
+      assert.strictEqual(result.imported, 2);
+      assert.strictEqual(result.overwritten, 0);
+
+      const notesFiles = service.getScratchFiles().filter(file => file.name === 'notes.md');
+      assert.strictEqual(notesFiles.length, 2);
+      assert.notStrictEqual(notesFiles[0].backingFileName, notesFiles[1].backingFileName);
+
+      const folderMap = new Map(service.getFolders().map(folder => [folder.id, folder.name]));
+      const fileByFolderName = new Map(notesFiles.map(file => [folderMap.get(file.parentId!), file]));
+
+      assert.strictEqual(service.loadFileContent(fileByFolderName.get('a')!.id), '# Folder A');
+      assert.strictEqual(service.loadFileContent(fileByFolderName.get('b')!.id), '# Folder B');
     });
 
     test('reports correct count when limit is reached', async () => {
@@ -409,6 +435,107 @@ suite('ScratchpadService - import from directory', () => {
       await service.addFolder('_import_3', undefined);
       const name = service.findNextImportFolderName();
       assert.strictEqual(name, '_import_2');
+    });
+  });
+
+  suite('migration', () => {
+    test('applies cumulative migration for long-skipped scratchpads', async () => {
+      const storage = createNamespacedStorage(mockContext, 'scratchpads');
+      await storage.store('metadata', {
+        version: 1,
+        files: [
+          {
+            id: 'legacy-a',
+            name: 'notes.md',
+            content: '# Legacy A',
+            createdAt: 1,
+            lastModified: 2,
+            order: 0
+          },
+          {
+            id: 'legacy-b',
+            name: 'notes.md',
+            content: '# Legacy B',
+            createdAt: 3,
+            lastModified: 4,
+            order: 1
+          }
+        ]
+      }, { scope: 'auto' });
+
+      service = new ScratchpadService(mockContext);
+      await service.loadScratchFiles();
+
+      const migratedFiles = service.getScratchFiles();
+      assert.strictEqual(migratedFiles.length, 2);
+      assert.strictEqual(migratedFiles.every(file => file.parentId === undefined), true);
+      assert.strictEqual(migratedFiles.every(file => !!file.backingFileName), true);
+      assert.strictEqual(new Set(migratedFiles.map(file => file.backingFileName)).size, 2);
+      assert.strictEqual(service.loadFileContent('legacy-a'), '# Legacy A');
+      assert.strictEqual(service.loadFileContent('legacy-b'), '# Legacy B');
+
+      const stored = await storage.retrieve<any>('metadata', undefined, { scope: 'auto' });
+      assert.strictEqual(stored.version, 3);
+      assert.strictEqual('content' in stored.files[0], false);
+      assert.strictEqual('content' in stored.files[1], false);
+      assert.strictEqual(fs.readFileSync(service.getFilePath('legacy-a'), 'utf8'), '# Legacy A');
+      assert.strictEqual(fs.readFileSync(service.getFilePath('legacy-b'), 'utf8'), '# Legacy B');
+    });
+
+    test('does not rewrite metadata from a newer scratchpad version', async () => {
+      const storage = createNamespacedStorage(mockContext, 'scratchpads');
+      await storage.store('metadata', {
+        version: 99,
+        files: [
+          {
+            id: 'future-file',
+            name: 'future.md',
+            content: '# Future',
+            backingFileName: 'future-storage.md',
+            createdAt: 1,
+            lastModified: 2,
+            order: 0,
+            parentId: undefined
+          }
+        ],
+        folders: []
+      }, { scope: 'auto' });
+
+      service = new ScratchpadService(mockContext);
+      await service.loadScratchFiles();
+
+      const stored = await storage.retrieve<any>('metadata', undefined, { scope: 'auto' });
+      assert.strictEqual(stored.version, 99);
+      assert.strictEqual(stored.files[0].backingFileName, 'future-storage.md');
+    });
+
+    test('strips legacy content from unreleased version 3 metadata', async () => {
+      const storage = createNamespacedStorage(mockContext, 'scratchpads');
+      await storage.store('metadata', {
+        version: 3,
+        files: [
+          {
+            id: 'dev-v3-file',
+            name: 'draft.md',
+            content: '# Draft',
+            backingFileName: 'dev-v3-file.md',
+            createdAt: 1,
+            lastModified: 2,
+            order: 0,
+            parentId: undefined
+          }
+        ],
+        folders: []
+      }, { scope: 'auto' });
+
+      service = new ScratchpadService(mockContext);
+      await service.loadScratchFiles();
+
+      assert.strictEqual(service.loadFileContent('dev-v3-file'), '# Draft');
+
+      const stored = await storage.retrieve<any>('metadata', undefined, { scope: 'auto' });
+      assert.strictEqual(stored.version, 3);
+      assert.strictEqual('content' in stored.files[0], false);
     });
   });
 });

--- a/src/test/features/scratchpad-rename-extension.test.ts
+++ b/src/test/features/scratchpad-rename-extension.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 import { ScratchpadService } from '../../features/scratchpads/ScratchpadService';
 import { createMockExtensionContext } from '../testUtils';
 
@@ -25,29 +26,35 @@ suite('Scratchpad rename: extension handling and spaces', () => {
 
   test('preserves original extension when none provided in new name', async () => {
     const f = await service.createScratchFile('scratchpad_1.json', 'json');
+    const originalBackingFile = path.basename(service.getFilePath(f.id));
 
     await service.renameScratchFile(f.id, 'some json'); // no extension provided
 
     const updated = service.getScratchFile(f.id)!;
     assert.strictEqual(updated.name, 'some json.json');
+    assert.strictEqual(updated.backingFileName, originalBackingFile);
   });
 
   test('replaces extension when one is provided in new name', async () => {
     const f = await service.createScratchFile('scratchpad_2.json', 'json');
+    const originalBackingFile = path.basename(service.getFilePath(f.id));
 
     await service.renameScratchFile(f.id, 'some.txt'); // explicit extension
 
     const updated = service.getScratchFile(f.id)!;
     assert.strictEqual(updated.name, 'some.txt');
+    assert.strictEqual(updated.backingFileName, originalBackingFile);
   });
 
   test('allows spaces in the middle of file name', async () => {
     const f = await service.createScratchFile('scratchpad_3.json', 'json');
+    const originalBackingFile = path.basename(service.getFilePath(f.id));
 
     await service.renameScratchFile(f.id, 'some json.json');
 
     const updated = service.getScratchFile(f.id)!;
     assert.strictEqual(updated.name, 'some json.json');
+    assert.strictEqual(updated.backingFileName, originalBackingFile);
   });
 });
 

--- a/src/test/features/scratchpad-service-folders.test.ts
+++ b/src/test/features/scratchpad-service-folders.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 import { ScratchpadService } from '../../features/scratchpads/ScratchpadService';
 import { createMockExtensionContext } from '../testUtils';
 
@@ -78,13 +79,27 @@ suite('ScratchpadService - folders', () => {
       assert.strictEqual(service.getFolderById(gc.id), undefined);
     });
 
-    test('deleteFolder moves contained files to root', async () => {
+    test('deleteFolder removes contained files recursively', async () => {
       const folder = await service.addFolder('Folder');
       const file = await service.createScratchFile('test.txt');
       await service.moveToFolder(file.id, folder.id);
+
+      const nestedFolder = await service.addFolder('Nested', folder.id);
+      const nestedFile = await service.createScratchFile('nested.txt');
+      await service.moveToFolder(nestedFile.id, nestedFolder.id);
+
+      const rootFilePath = service.getFilePath(file.id);
+      const nestedFilePath = service.getFilePath(nestedFile.id);
+      assert.strictEqual(fs.existsSync(rootFilePath), true);
+      assert.strictEqual(fs.existsSync(nestedFilePath), true);
+
       await service.deleteFolder(folder.id);
-      const movedFile = service.getScratchFile(file.id);
-      assert.strictEqual(movedFile?.parentId, undefined);
+
+      assert.strictEqual(service.getScratchFile(file.id), undefined);
+      assert.strictEqual(service.getScratchFile(nestedFile.id), undefined);
+      assert.strictEqual(service.getFolderById(nestedFolder.id), undefined);
+      assert.strictEqual(fs.existsSync(rootFilePath), false);
+      assert.strictEqual(fs.existsSync(nestedFilePath), false);
     });
   });
 

--- a/src/test/features/scratchpad-service-folders.test.ts
+++ b/src/test/features/scratchpad-service-folders.test.ts
@@ -154,21 +154,27 @@ suite('ScratchpadService - folders', () => {
       );
     });
 
-    test('throws when moving folder would exceed max depth (5)', async () => {
+    test('throws when moving folder would exceed max depth (10)', async () => {
       // Build two parallel chains so that we don't trigger isDescendantOf
-      // Chain 1: l1 -> l2 -> l3 -> l4 (depth 4 at l4)
+      // Chain 1: l1 -> l2 -> ... -> l10 (depth 10 at l10)
       const l1 = await service.addFolder('L1');
       const l2 = await service.addFolder('L2', l1.id);
       const l3 = await service.addFolder('L3', l2.id);
       const l4 = await service.addFolder('L4', l3.id);
+      const l5 = await service.addFolder('L5', l4.id);
+      const l6 = await service.addFolder('L6', l5.id);
+      const l7 = await service.addFolder('L7', l6.id);
+      const l8 = await service.addFolder('L8', l7.id);
+      const l9 = await service.addFolder('L9', l8.id);
+      const l10 = await service.addFolder('L10', l9.id);
       // Chain 2: r1 -> r2 (depth 2 at r2)
       const r1 = await service.addFolder('R1');
       const r2 = await service.addFolder('R2', r1.id);
-      // l4 is at depth 4, r2 is at depth 2
-      // moveToFolder(l1, r2) -> targetDepth(r2)=2 + maxFolderDepth(l1)=4 = 6 > 5
+      // l10 is at depth 10, r2 is at depth 2
+      // moveToFolder(l1, r2) -> targetDepth(r2)=2 + maxFolderDepth(l1)=10 = 12 > 10
       await assert.rejects(
         () => service.moveToFolder(l1.id, r2.id),
-        /exceed maximum depth.*5 levels/
+        /exceed maximum depth.*10 levels/
       );
     });
 

--- a/src/test/features/scratchpad-validator.test.ts
+++ b/src/test/features/scratchpad-validator.test.ts
@@ -71,19 +71,19 @@ suite('ScratchpadValidator', () => {
       assert.strictEqual(ScratchpadValidator.validateTotalCount(files), null);
     });
 
-    test('returns error when at 200 files (limit reached)', () => {
-      const files = Array.from({ length: 200 }, (_, i) => ({ id: `file-${i}` }));
+    test('returns error when at 400 files (limit reached)', () => {
+      const files = Array.from({ length: 400 }, (_, i) => ({ id: `file-${i}` }));
       assert.strictEqual(
         ScratchpadValidator.validateTotalCount(files),
-        'Maximum of 200 scratchpads reached.'
+        'Maximum of 400 scratchpads reached.'
       );
     });
 
     test('returns error when over limit', () => {
-      const files = Array.from({ length: 201 }, (_, i) => ({ id: `file-${i}` }));
+      const files = Array.from({ length: 401 }, (_, i) => ({ id: `file-${i}` }));
       assert.strictEqual(
         ScratchpadValidator.validateTotalCount(files),
-        'Maximum of 200 scratchpads reached.'
+        'Maximum of 400 scratchpads reached.'
       );
     });
   });

--- a/src/test/integration/ai-tools-registration.test.ts
+++ b/src/test/integration/ai-tools-registration.test.ts
@@ -48,7 +48,9 @@ suite('AI tools registration', () => {
       'codebench_rename_scratchpad',
       'codebench_delete_scratchpad',
       'codebench_create_scratchpad_folder',
+      'codebench_rename_scratchpad_folder',
       'codebench_move_scratchpad_to_folder',
+      'codebench_move_scratchpad_folder',
       'codebench_delete_scratchpad_folder'
     ];
 

--- a/src/test/integration/scratchpads-commands.test.ts
+++ b/src/test/integration/scratchpads-commands.test.ts
@@ -56,6 +56,10 @@ suite('Scratchpads: command-driven flows', () => {
     // Open scratch file via provider API
     await scratchpadsProvider.openScratchFile(renamed.id);
 
+    const scratchpadDoc = vscode.window.activeTextEditor?.document;
+    assert.ok(scratchpadDoc, 'Scratchpad document should be opened');
+    assert.strictEqual(scratchpadDoc?.uri.scheme, 'codebench-scratchpad');
+
     // Delete directly via service to avoid modal confirm
     await scratchpadsProvider.scratchpadService.deleteScratchFile(renamed.id);
     files = scratchpadsProvider.scratchpadService.getScratchFiles();
@@ -84,7 +88,11 @@ suite('Scratchpads: command-driven flows', () => {
     assert.strictEqual(files.length, 1, 'One scratchpad should be created');
     assert.strictEqual(files[0].name.endsWith('.md'), true, 'Scratchpad should use .md extension');
     assert.strictEqual(files[0].name.startsWith('scratchpad_'), true, 'Scratchpad should keep naming convention');
-    assert.strictEqual(files[0].content, content, 'Scratchpad should preserve untitled editor content');
+    assert.strictEqual(
+      scratchpadsProvider.scratchpadService.loadFileContent(files[0].id),
+      content,
+      'Scratchpad should preserve untitled editor content'
+    );
 
     const hasUntitledTab = vscode.window.tabGroups.all
       .flatMap(group => group.tabs)
@@ -116,7 +124,11 @@ suite('Scratchpads: command-driven flows', () => {
     const files = scratchpadsProvider.scratchpadService.getScratchFiles();
     assert.strictEqual(files.length, 1, 'One scratchpad should be created');
     assert.strictEqual(files[0].name.endsWith('.txt'), true, 'Unknown language should fall back to .txt');
-    assert.strictEqual(files[0].content, content, 'Scratchpad should preserve untitled editor content');
+    assert.strictEqual(
+      scratchpadsProvider.scratchpadService.loadFileContent(files[0].id),
+      content,
+      'Scratchpad should preserve untitled editor content'
+    );
   });
 
   test('Delete scratchpad folder asks for confirmation and deletes subtree on confirm', async function () {
@@ -179,6 +191,41 @@ suite('Scratchpads: command-driven flows', () => {
 
     assert.ok(scratchpadsProvider.scratchpadService.getFolderById(folder.id), 'Folder should remain after cancel');
     assert.ok(scratchpadsProvider.scratchpadService.getScratchFile(file.id), 'Contained file should remain after cancel');
+  });
+
+  test('Opens same-named scratchpads from different folders as distinct documents', async function () {
+    this.timeout(20000);
+    const { scratchpadsProvider } = extension.exports as any;
+    assert.ok(scratchpadsProvider, 'scratchpadsProvider should be available');
+
+    for (const f of [...scratchpadsProvider.scratchpadService.getScratchFiles()]) {
+      await scratchpadsProvider.scratchpadService.deleteScratchFile(f.id);
+    }
+    for (const folder of [...scratchpadsProvider.scratchpadService.getFolders()]) {
+      await scratchpadsProvider.deleteFolderForTools(folder.id);
+    }
+
+    const folderA = await scratchpadsProvider.addFolder('Folder A');
+    const folderB = await scratchpadsProvider.addFolder('Folder B');
+    const first = await scratchpadsProvider.scratchpadService.createScratchFile('notes.md', 'markdown', folderA.id);
+    const second = await scratchpadsProvider.scratchpadService.createScratchFile('notes.md', 'markdown', folderB.id);
+
+    await scratchpadsProvider.scratchpadService.updateFileContent(first.id, '# A');
+    await scratchpadsProvider.scratchpadService.updateFileContent(second.id, '# B');
+
+    await scratchpadsProvider.openScratchFile(first.id);
+    const firstDoc = vscode.window.activeTextEditor?.document;
+
+    await scratchpadsProvider.openScratchFile(second.id);
+    const secondDoc = vscode.window.activeTextEditor?.document;
+
+    assert.ok(firstDoc, 'First scratchpad document should be opened');
+    assert.ok(secondDoc, 'Second scratchpad document should be opened');
+    assert.strictEqual(firstDoc?.uri.scheme, 'codebench-scratchpad');
+    assert.strictEqual(secondDoc?.uri.scheme, 'codebench-scratchpad');
+    assert.notStrictEqual(firstDoc?.uri.toString(), secondDoc?.uri.toString());
+    assert.strictEqual(firstDoc?.getText(), '# A');
+    assert.strictEqual(secondDoc?.getText(), '# B');
   });
 });
 

--- a/src/test/integration/scratchpads-commands.test.ts
+++ b/src/test/integration/scratchpads-commands.test.ts
@@ -118,5 +118,67 @@ suite('Scratchpads: command-driven flows', () => {
     assert.strictEqual(files[0].name.endsWith('.txt'), true, 'Unknown language should fall back to .txt');
     assert.strictEqual(files[0].content, content, 'Scratchpad should preserve untitled editor content');
   });
+
+  test('Delete scratchpad folder asks for confirmation and deletes subtree on confirm', async function () {
+    this.timeout(20000);
+    const { scratchpadsProvider } = extension.exports as any;
+    assert.ok(scratchpadsProvider, 'scratchpadsProvider should be available');
+
+    for (const f of [...scratchpadsProvider.scratchpadService.getScratchFiles()]) {
+      await scratchpadsProvider.scratchpadService.deleteScratchFile(f.id);
+    }
+    for (const folder of [...scratchpadsProvider.scratchpadService.getFolders()]) {
+      await scratchpadsProvider.deleteFolderForTools(folder.id);
+    }
+
+    const rootFolder = await scratchpadsProvider.addFolder('Root Folder');
+    const childFolder = await scratchpadsProvider.addFolder('Child Folder', rootFolder.id);
+    const rootFile = await scratchpadsProvider.scratchpadService.createScratchFile('root.md');
+    const childFile = await scratchpadsProvider.scratchpadService.createScratchFile('child.md');
+
+    await scratchpadsProvider.scratchpadService.moveToFolder(rootFile.id, rootFolder.id);
+    await scratchpadsProvider.scratchpadService.moveToFolder(childFile.id, childFolder.id);
+
+    let warningMessage: string | undefined;
+    stub(vscode.window, 'showWarningMessage', async (message: string) => {
+      warningMessage = message;
+      return 'Delete';
+    });
+
+    await vscode.commands.executeCommand('vs-codebench.deleteScratchpadFolder', { id: rootFolder.id });
+
+    assert.strictEqual(
+      warningMessage,
+      'Are you sure you want to delete "Root Folder"? This will delete 3 item(s) including all subfolders and scratchpads.'
+    );
+    assert.strictEqual(scratchpadsProvider.scratchpadService.getFolderById(rootFolder.id), undefined);
+    assert.strictEqual(scratchpadsProvider.scratchpadService.getFolderById(childFolder.id), undefined);
+    assert.strictEqual(scratchpadsProvider.scratchpadService.getScratchFile(rootFile.id), undefined);
+    assert.strictEqual(scratchpadsProvider.scratchpadService.getScratchFile(childFile.id), undefined);
+  });
+
+  test('Delete scratchpad folder keeps subtree when confirmation is cancelled', async function () {
+    this.timeout(20000);
+    const { scratchpadsProvider } = extension.exports as any;
+    assert.ok(scratchpadsProvider, 'scratchpadsProvider should be available');
+
+    for (const f of [...scratchpadsProvider.scratchpadService.getScratchFiles()]) {
+      await scratchpadsProvider.scratchpadService.deleteScratchFile(f.id);
+    }
+    for (const folder of [...scratchpadsProvider.scratchpadService.getFolders()]) {
+      await scratchpadsProvider.deleteFolderForTools(folder.id);
+    }
+
+    const folder = await scratchpadsProvider.addFolder('Keep Folder');
+    const file = await scratchpadsProvider.scratchpadService.createScratchFile('keep.md');
+    await scratchpadsProvider.scratchpadService.moveToFolder(file.id, folder.id);
+
+    stub(vscode.window, 'showWarningMessage', async () => undefined);
+
+    await vscode.commands.executeCommand('vs-codebench.deleteScratchpadFolder', { id: folder.id });
+
+    assert.ok(scratchpadsProvider.scratchpadService.getFolderById(folder.id), 'Folder should remain after cancel');
+    assert.ok(scratchpadsProvider.scratchpadService.getScratchFile(file.id), 'Contained file should remain after cancel');
+  });
 });
 

--- a/src/test/integration/scratchpads-commands.test.ts
+++ b/src/test/integration/scratchpads-commands.test.ts
@@ -38,7 +38,7 @@ suite('Scratchpads: command-driven flows', () => {
     // Create scratchpad via command with stubbed inputs
     stub(vscode.window, 'showInputBox', async () => 'notes.md');
     // If language is requested via quick pick, return 'markdown'
-    stub(vscode.window, 'showQuickPick', async () => ({ label: 'markdown' } as any));
+    stub(vscode.window, 'showQuickPick', async () => ({ label: 'Markdown', extension: '.md' } as any));
 
     await vscode.commands.executeCommand('vs-codebench.createScratchpad');
 
@@ -167,6 +167,30 @@ suite('Scratchpads: command-driven flows', () => {
     assert.strictEqual(scratchpadsProvider.scratchpadService.getFolderById(childFolder.id), undefined);
     assert.strictEqual(scratchpadsProvider.scratchpadService.getScratchFile(rootFile.id), undefined);
     assert.strictEqual(scratchpadsProvider.scratchpadService.getScratchFile(childFile.id), undefined);
+  });
+
+  test('Create scratchpad in folder via command assigns parent folder', async function () {
+    this.timeout(20000);
+    const { scratchpadsProvider } = extension.exports as any;
+    assert.ok(scratchpadsProvider, 'scratchpadsProvider should be available');
+
+    for (const f of [...scratchpadsProvider.scratchpadService.getScratchFiles()]) {
+      await scratchpadsProvider.scratchpadService.deleteScratchFile(f.id);
+    }
+    for (const folder of [...scratchpadsProvider.scratchpadService.getFolders()]) {
+      await scratchpadsProvider.deleteFolderForTools(folder.id);
+    }
+
+    const parentFolder = await scratchpadsProvider.addFolder('Parent Folder');
+
+    stub(vscode.window, 'showQuickPick', async () => ({ label: 'Markdown', extension: '.md' } as any));
+
+    await vscode.commands.executeCommand('vs-codebench.createScratchpadInFolder', { id: parentFolder.id });
+
+    const files = scratchpadsProvider.scratchpadService.getScratchFiles();
+    assert.strictEqual(files.length, 1, 'One scratchpad should be created');
+    assert.strictEqual(files[0].parentId, parentFolder.id, 'Scratchpad should be created in the selected folder');
+    assert.strictEqual(files[0].name.endsWith('.md'), true, 'Scratchpad should use the selected extension');
   });
 
   test('Delete scratchpad folder keeps subtree when confirmation is cancelled', async function () {

--- a/src/test/integration/ui-workflow.test.ts
+++ b/src/test/integration/ui-workflow.test.ts
@@ -164,6 +164,7 @@ console.log('Even numbers:', evenNumbers);`;
     assert.ok(commands.includes('vs-codebench.toggleBookmark'), 'Toggle bookmark command should be registered');
     assert.ok(commands.includes('vs-codebench.addTodo'), 'Add todo command should be registered');
     assert.ok(commands.includes('vs-codebench.createScratchpad'), 'Create scratchpad command should be registered');
+    assert.ok(commands.includes('vs-codebench.createScratchpadInFolder'), 'Create scratchpad in folder command should be registered');
   });
 
   test('Test tree view visibility', async function () {


### PR DESCRIPTION
## Summary
This release packages the scratchpad work on `feature/import-scratchpads` into version `1.3.0`.

It adds a full scratchpad import workflow, moves scratchpads to a dedicated `codebench-scratchpad` virtual file system, expands folder-aware actions and Copilot tools, and updates the release metadata for publishing.

## What changed
- Added scratchpad import from a selected directory.
- Preserved imported folder structure, skipped binary files and symlinks, overwrote matching scratchpads in place, and generated an import summary scratchpad.
- Switched scratchpad editors to `codebench-scratchpad` URIs so display names and folder paths are no longer coupled to backing file names on disk.
- Added migration and storage handling for v3 scratchpad metadata, including backing file name persistence and duplicate-name collision handling.
- Added create-in-folder scratchpad actions and expanded scratchpad folder operations.
- Changed scratchpad folder deletion to recursive deletion with confirmation and backing file cleanup.
- Expanded GitHub Copilot scratchpad tools to cover listing, content access, folder create/rename/move/delete, and moves back to root.
- Increased scratchpad capacity to 400 files and extended folder depth handling to 10 levels for imports and moves.
- Updated README, changelog, and extension version to `1.3.0`.

## Why this release matters
Scratchpads now behave more like a first-class workspace feature:
- importing existing note/code folders is built in,
- logical scratchpad identity is stable even if storage changes underneath,
- folder operations are safer and more complete,
- Copilot has enough surface area to manage scratchpads end-to-end.

## Validation
- Ran `npm run compile`

## Notes
This PR includes both the feature work and the release packaging for `1.3.0`.